### PR TITLE
test: 归一主仓 tests/ 11 测试 + 合并 backend/run-status-schema 用例

### DIFF
--- a/test/one_dragon/base/matcher/ocr/ocr_utils/test_match_word_list_by_priority.py
+++ b/test/one_dragon/base/matcher/ocr/ocr_utils/test_match_word_list_by_priority.py
@@ -1,0 +1,268 @@
+"""
+测试 match_word_list_by_priority 函数的各种场景
+"""
+
+import pytest
+from unittest.mock import patch
+
+from one_dragon.base.matcher.match_result import MatchResult, MatchResultList
+from one_dragon.base.matcher.ocr.ocr_utils import match_word_list_by_priority
+
+
+class TestMatchWordListByPriority:
+    @pytest.fixture
+    def sample_ocr_result_map(self):
+        """创建示例OCR结果映射"""
+        result_map = {}
+
+        # 创建一些匹配结果
+        claim_result = MatchResultList(only_best=False)
+        claim_result.append(MatchResult(0.9, 10, 10, 50, 20, data="领取"))
+        result_map["领取"] = claim_result
+
+        claimed_result = MatchResultList(only_best=False)
+        claimed_result.append(MatchResult(0.8, 10, 40, 80, 20, data="已领取"))
+        result_map["已领取"] = claimed_result
+
+        start_result = MatchResultList(only_best=False)
+        start_result.append(MatchResult(0.85, 10, 70, 60, 20, data="开始"))
+        result_map["开始"] = start_result
+
+        return result_map
+
+    @pytest.fixture
+    def empty_ocr_result_map(self):
+        """创建空的OCR结果映射"""
+        return {}
+
+    @patch("one_dragon.base.matcher.ocr.ocr_utils.gt")
+    @patch("one_dragon.utils.str_utils.find_best_match_by_difflib")
+    def test_basic_priority_matching(
+        self, mock_find_match, mock_gt, sample_ocr_result_map
+    ):
+        """测试基本的优先级匹配功能"""
+        # Mock gt函数直接返回原值
+        mock_gt.side_effect = lambda x, mode: x
+
+        # Mock find_best_match_by_difflib 返回精确匹配
+        mock_find_match.side_effect = (
+            lambda word, targets: targets.index(word) if word in targets else None
+        )
+
+        word_list = ["领取", "已领取", "开始"]
+
+        result_word, result_list = match_word_list_by_priority(
+            sample_ocr_result_map, word_list
+        )
+
+        assert result_word == "领取"
+        assert result_list is not None
+        assert len(result_list) == 1
+        assert result_list[0].data == "领取"
+
+    @patch("one_dragon.base.matcher.ocr.ocr_utils.gt")
+    @patch("one_dragon.utils.str_utils.find_best_match_by_difflib")
+    def test_priority_order_respected(
+        self, mock_find_match, mock_gt, sample_ocr_result_map
+    ):
+        """测试优先级顺序被正确遵循"""
+        mock_gt.side_effect = lambda x, mode: x
+
+        # 模拟所有词都能匹配，但应该返回优先级最高的
+        mock_find_match.side_effect = (
+            lambda word, targets: 0 if word == "开始" else targets.index(word)
+        )
+
+        word_list = ["开始", "领取", "已领取"]
+
+        result_word, result_list = match_word_list_by_priority(
+            sample_ocr_result_map, word_list
+        )
+
+        # 应该返回优先级最高的"开始"，即使"领取"在OCR结果中存在
+        assert result_word == "开始"
+
+    @patch("one_dragon.base.matcher.ocr.ocr_utils.gt")
+    @patch("one_dragon.utils.str_utils.find_best_match_by_difflib")
+    def test_ignore_list_functionality(
+        self, mock_find_match, mock_gt, sample_ocr_result_map
+    ):
+        """测试忽略列表功能"""
+        mock_gt.side_effect = lambda x, mode: x
+        mock_find_match.side_effect = (
+            lambda word, targets: targets.index(word) if word in targets else None
+        )
+
+        word_list = ["领取", "已领取", "开始"]
+        ignore_list = ["领取"]  # 忽略"领取"
+
+        result_word, result_list = match_word_list_by_priority(
+            sample_ocr_result_map, word_list, ignore_list
+        )
+
+        # 应该跳过"领取"，返回"已领取"
+        assert result_word == "已领取"
+        assert result_list is not None
+
+    @patch("one_dragon.base.matcher.ocr.ocr_utils.gt")
+    @patch("one_dragon.utils.str_utils.find_best_match_by_difflib")
+    def test_no_matches_found(self, mock_find_match, mock_gt, sample_ocr_result_map):
+        """测试没有找到匹配时的情况"""
+        mock_gt.side_effect = lambda x, mode: x
+        mock_find_match.return_value = None  # 没有匹配
+
+        word_list = ["不存在", "也不存在"]
+
+        result_word, result_list = match_word_list_by_priority(
+            sample_ocr_result_map, word_list
+        )
+
+        assert result_word is None
+        assert result_list is None
+
+    @patch("one_dragon.base.matcher.ocr.ocr_utils.gt")
+    @patch("one_dragon.utils.str_utils.find_best_match_by_difflib")
+    def test_empty_ocr_result_map(self, mock_find_match, mock_gt, empty_ocr_result_map):
+        """测试空的OCR结果映射"""
+        mock_gt.side_effect = lambda x, mode: x
+
+        word_list = ["领取", "开始"]
+
+        result_word, result_list = match_word_list_by_priority(
+            empty_ocr_result_map, word_list
+        )
+
+        assert result_word is None
+        assert result_list is None
+
+    @patch("one_dragon.base.matcher.ocr.ocr_utils.gt")
+    @patch("one_dragon.utils.str_utils.find_best_match_by_difflib")
+    def test_empty_word_list(self, mock_find_match, mock_gt, sample_ocr_result_map):
+        """测试空的词列表"""
+        mock_gt.side_effect = lambda x, mode: x
+        mock_find_match.return_value = None  # 对于空列表，永远返回 None
+
+        word_list = []
+
+        result_word, result_list = match_word_list_by_priority(
+            sample_ocr_result_map, word_list
+        )
+
+        assert result_word is None
+        assert result_list is None
+
+    @patch("one_dragon.base.matcher.ocr.ocr_utils.gt")
+    @patch("one_dragon.utils.str_utils.find_best_match_by_difflib")
+    def test_i18n_translation(self, mock_find_match, mock_gt, sample_ocr_result_map):
+        """测试国际化翻译功能"""
+        # Mock gt函数返回翻译后的值
+        mock_gt.side_effect = lambda x, mode: f"{x}_translated"
+
+        # Mock find_best_match_by_difflib 匹配翻译后的值
+        mock_find_match.return_value = 0
+
+        word_list = ["领取", "开始"]
+
+        result_word, result_list = match_word_list_by_priority(
+            sample_ocr_result_map, word_list
+        )
+
+        # 验证gt被调用
+        assert mock_gt.call_count == 2
+        # 应该返回原始词，不是翻译后的词
+        assert result_word == "领取"
+
+    @patch("one_dragon.base.matcher.ocr.ocr_utils.gt")
+    @patch("one_dragon.utils.str_utils.find_best_match_by_difflib")
+    def test_multiple_matches_for_same_word(self, mock_find_match, mock_gt):
+        """测试同一个词有多个匹配结果的情况"""
+        mock_gt.side_effect = lambda x, mode: x
+        mock_find_match.side_effect = (
+            lambda word, targets: targets.index(word) if word in targets else None
+        )
+
+        # 创建包含多个匹配结果的OCR映射
+        result_map = {}
+        claim_results = MatchResultList(only_best=False)
+        claim_results.append(MatchResult(0.9, 10, 10, 50, 20, data="领取"))
+        claim_results.append(MatchResult(0.8, 70, 10, 50, 20, data="领取"))
+        result_map["领取"] = claim_results
+
+        word_list = ["领取"]
+
+        result_word, result_list = match_word_list_by_priority(result_map, word_list)
+
+        assert result_word == "领取"
+        assert result_list is not None
+        assert len(result_list) == 2
+
+    @patch("one_dragon.base.matcher.ocr.ocr_utils.gt")
+    @patch("one_dragon.utils.str_utils.find_best_match_by_difflib")
+    def test_fuzzy_matching_with_difflib(
+        self, mock_find_match, mock_gt, sample_ocr_result_map
+    ):
+        """测试使用difflib进行模糊匹配"""
+        mock_gt.side_effect = lambda x, mode: x
+
+        # 模拟模糊匹配情况：OCR识别结果"已领取*1"应该匹配到"已领取"
+        def mock_fuzzy_match(word, targets):
+            if "已领取*1" in word and "已领取" in targets:
+                return targets.index("已领取")
+            return targets.index(word) if word in targets else None
+
+        # 创建包含模糊匹配的OCR映射
+        fuzzy_result_map = {}
+        claimed_result = MatchResultList(only_best=False)
+        claimed_result.append(MatchResult(0.8, 10, 40, 100, 20, data="已领取*1"))
+        fuzzy_result_map["已领取*1"] = claimed_result
+
+        word_list = ["领取", "已领取"]
+        mock_find_match.side_effect = mock_fuzzy_match
+
+        result_word, result_list = match_word_list_by_priority(
+            fuzzy_result_map, word_list
+        )
+
+        assert result_word == "已领取"
+        assert result_list is not None
+        assert result_list[0].data == "已领取*1"
+
+    @patch("one_dragon.base.matcher.ocr.ocr_utils.gt")
+    @patch("one_dragon.utils.str_utils.find_best_match_by_difflib")
+    def test_all_ignored_words(self, mock_find_match, mock_gt, sample_ocr_result_map):
+        """测试所有词都被忽略的情况"""
+        mock_gt.side_effect = lambda x, mode: x
+        mock_find_match.side_effect = (
+            lambda word, targets: targets.index(word) if word in targets else None
+        )
+
+        word_list = ["领取", "已领取"]
+        ignore_list = ["领取", "已领取"]  # 忽略所有词
+
+        result_word, result_list = match_word_list_by_priority(
+            sample_ocr_result_map, word_list, ignore_list
+        )
+
+        assert result_word is None
+        assert result_list is None
+
+    @patch("one_dragon.base.matcher.ocr.ocr_utils.gt")
+    @patch("one_dragon.utils.str_utils.find_best_match_by_difflib")
+    def test_partial_ignore_list(self, mock_find_match, mock_gt, sample_ocr_result_map):
+        """测试部分忽略列表的情况"""
+        mock_gt.side_effect = lambda x, mode: x
+        mock_find_match.side_effect = (
+            lambda word, targets: targets.index(word) if word in targets else None
+        )
+
+        word_list = ["领取", "已领取", "开始"]
+        ignore_list = ["已领取"]  # 只忽略"已领取"
+
+        result_word, result_list = match_word_list_by_priority(
+            sample_ocr_result_map, word_list, ignore_list
+        )
+
+        # 应该返回"领取"，因为它是第一个非忽略的匹配项
+        assert result_word == "领取"
+        assert result_list is not None
+        assert result_list[0].data == "领取"

--- a/test/one_dragon/base/screen/test_screen_match.py
+++ b/test/one_dragon/base/screen/test_screen_match.py
@@ -1,0 +1,316 @@
+"""screen_match 框架强化匹配测试。"""
+from unittest.mock import MagicMock
+
+import one_dragon.base.screen.screen_match as _sm
+from one_dragon.base.geometry.rectangle import Rect
+from one_dragon.base.screen.screen_area import ScreenArea
+from one_dragon.base.screen.screen_info import ScreenInfo
+from one_dragon.base.screen.screen_match import (
+    AreaMatchDetail,
+    AreaType,
+    ScreenMatch,
+    find_area_with_detail,
+    find_screen_matches,
+)
+
+
+def test_area_type_is_str_enum() -> None:
+    """AreaType 是 str Enum,值 'text'/'template',可直接当字符串用。"""
+    assert AreaType.TEXT == 'text'
+    assert AreaType.TEMPLATE == 'template'
+    assert isinstance(AreaType.TEXT, str)
+
+
+def test_area_match_detail_text() -> None:
+    """文本命中详情构造(text 字段、置信度)。"""
+    d = AreaMatchDetail(area_name='菜单标题', area_type=AreaType.TEXT,
+                        x=120, y=40, width=280, height=50, text='菜单', confidence=0.95)
+    assert d.area_name == '菜单标题'
+    assert d.area_type == AreaType.TEXT
+    assert d.text == '菜单'
+    assert d.confidence == 0.95
+
+
+def test_area_match_detail_template_optional_text() -> None:
+    """模板命中详情 text 默认 None。"""
+    d = AreaMatchDetail(area_name='邮箱', area_type=AreaType.TEMPLATE,
+                        x=1700, y=40, width=60, height=60, confidence=0.92)
+    assert d.text is None
+    assert d.confidence == 0.92
+
+
+def test_screen_match_construction() -> None:
+    """ScreenMatch 构造(is_precise / areas 列表)。"""
+    d = AreaMatchDetail(area_name='标题', area_type=AreaType.TEXT,
+                        x=1, y=1, width=1, height=1)
+    m = ScreenMatch(screen_name='菜单', is_precise=True, areas=[d])
+    assert m.screen_name == '菜单'
+    assert m.is_precise is True
+    assert len(m.areas) == 1
+
+
+def _text_area(text: str = '战斗') -> ScreenArea:
+    return ScreenArea(area_name=f'按钮-{text}', pc_rect=Rect(300, 800, 500, 880),
+                      text=text, lcs_percent=0.5)
+
+
+def _template_area() -> ScreenArea:
+    return ScreenArea(area_name='邮箱图标', pc_rect=Rect(1700, 40, 1760, 100),
+                      template_id='mail', template_sub_dir='menu',
+                      template_match_threshold=0.7)
+
+
+def _plain_area() -> ScreenArea:
+    return ScreenArea(area_name='点击区', pc_rect=Rect(0, 0, 100, 100))
+
+
+def test_find_area_text_match_returns_detail() -> None:
+    ctx = MagicMock()
+    ocr = MagicMock(data='战斗', confidence=0.95, x=300, y=800, w=200, h=80)
+    ctx.ocr_service.get_ocr_result_list.return_value = [ocr]
+    d = find_area_with_detail(ctx, MagicMock(), _text_area())
+    assert d is not None
+    assert d.area_type == AreaType.TEXT
+    assert d.text == '战斗'
+    assert d.confidence == 0.95
+    assert (d.x, d.y, d.width, d.height) == (300, 800, 200, 80)
+
+
+def test_find_area_text_no_match_returns_none() -> None:
+    ctx = MagicMock()
+    ocr = MagicMock(data='设置')
+    ctx.ocr_service.get_ocr_result_list.return_value = [ocr]
+    assert find_area_with_detail(ctx, MagicMock(), _text_area()) is None
+
+
+def test_find_area_template_match_absolute_coord() -> None:
+    """模板命中返回绝对坐标(mrl.max + area.rect 偏移)。"""
+    ctx = MagicMock()
+    mrl = MagicMock()
+    mrl.max = MagicMock(x=10, y=20, w=50, h=60, confidence=0.92)
+    ctx.tm.crop_and_match_template.return_value = mrl
+    d = find_area_with_detail(ctx, MagicMock(), _template_area())
+    assert d is not None
+    assert d.area_type == AreaType.TEMPLATE
+    assert d.confidence == 0.92
+    assert (d.x, d.y) == (1710, 60)      # 1700+10, 40+20
+    assert (d.width, d.height) == (50, 60)
+
+
+def test_find_area_template_no_match_returns_none() -> None:
+    ctx = MagicMock()
+    mrl = MagicMock()
+    mrl.max = None
+    ctx.tm.crop_and_match_template.return_value = mrl
+    assert find_area_with_detail(ctx, MagicMock(), _template_area()) is None
+
+
+def test_find_area_plain_returns_none() -> None:
+    """纯定位区域(无 text/template)返 None,不参与识别。"""
+    ctx = MagicMock()
+    assert find_area_with_detail(ctx, MagicMock(), _plain_area()) is None
+
+
+def test_find_area_default_crop_first_false() -> None:
+    """默认 crop_first=False(全图 OCR 缓存复用,与 find_area_in_screen 默认 True 相反)。"""
+    ctx = MagicMock()
+    ctx.ocr_service.get_ocr_result_list.return_value = []
+    find_area_with_detail(ctx, MagicMock(), _text_area())
+    _args, kwargs = ctx.ocr_service.get_ocr_result_list.call_args
+    assert kwargs.get('crop_first') is False
+
+
+# --- find_screen_matches 测试(find_screen_matches 一次遍历分级匹配)---
+
+
+def _screen_info(name: str, areas: list[ScreenArea]) -> ScreenInfo:
+    """用 ScreenInfo 构造一个画面(area_list 来自入参)。"""
+    data = {'screen_id': name, 'screen_name': name, 'app_id': '',
+            'area_list': [a.to_dict() for a in areas]}
+    return ScreenInfo(data)
+
+
+def _id_mark_text_area(name: str, text: str) -> ScreenArea:
+    a = ScreenArea(area_name=name, pc_rect=Rect(0, 0, 100, 50), text=text, lcs_percent=0.5)
+    a.id_mark = True
+    return a
+
+
+def _make_loader(screens: list[ScreenInfo], current: str | None = None,
+                 last: str | None = None) -> MagicMock:
+    """构造 mock screen_loader。"""
+    loader = MagicMock()
+    loader.screen_info_list = screens
+    loader.active_screen_info_list = screens
+    loader.screen_info_map = {s.screen_name: s for s in screens}
+    loader.active_screen_names = None   # backend 语境 scope 不激活
+    loader.current_screen_name = current
+    loader.last_screen_name = last
+    return loader
+
+
+def _patch_find(monkeypatch, hit_map: dict) -> None:
+    """patch 模块级 find_area_with_detail:按 area_name 决定命中(走 text 分支语义)。
+
+    必须用 monkeypatch.setattr(_sm, ...)patch 模块属性 —— find_screen_matches 内部以
+    模块级引用调用 find_area_with_detail(见实现注),patch 模块属性才生效。
+    """
+    def fake_find(ctx, screen, area, crop_first=False):
+        if area.area_name in hit_map and hit_map[area.area_name]:
+            return AreaMatchDetail(area_name=area.area_name, area_type=AreaType.TEXT,
+                                   x=0, y=0, width=10, height=10, text=area.text or '')
+        return None
+    monkeypatch.setattr(_sm, 'find_area_with_detail', fake_find)
+
+
+def test_precise_early_stop_when_current_set(monkeypatch) -> None:
+    """current 有值 + 该画面 id_mark 全中 → 精准早停返 1 个 is_precise=True。"""
+    menu = _screen_info('菜单', [_id_mark_text_area('菜单标题', '菜单')])
+    ctx = MagicMock()
+    ctx.screen_loader = _make_loader([menu], current='菜单')
+    _patch_find(monkeypatch, {'菜单标题': True})
+    result = find_screen_matches(ctx, MagicMock())
+    assert len(result) == 1
+    assert result[0].screen_name == '菜单'
+    assert result[0].is_precise is True
+
+
+def test_no_precise_returns_topn_by_hit_count(monkeypatch) -> None:
+    """无 id_mark 全中 → 按命中数 top_n(is_precise=False)。"""
+    a = _screen_info('画面A', [ScreenArea(area_name='a1', pc_rect=Rect(0, 0, 10, 10), text='x'),
+                               ScreenArea(area_name='a2', pc_rect=Rect(0, 0, 10, 10), text='y')])
+    b = _screen_info('画面B', [ScreenArea(area_name='b1', pc_rect=Rect(0, 0, 10, 10), text='z')])
+    ctx = MagicMock()
+    ctx.screen_loader = _make_loader([a, b])
+    _patch_find(monkeypatch, {'a1': True, 'a2': True, 'b1': True})
+    result = find_screen_matches(ctx, MagicMock(), top_n=5)
+    assert len(result) == 2
+    assert result[0].screen_name == '画面A'   # 命中 2 个,排前
+    assert result[0].is_precise is False
+    assert result[1].screen_name == '画面B'
+
+
+def test_current_last_none_full_traversal(monkeypatch) -> None:
+    """current/last 均 None → 直接全量遍历(无 BFS)。"""
+    menu = _screen_info('菜单', [_id_mark_text_area('标题', '菜单')])
+    ctx = MagicMock()
+    ctx.screen_loader = _make_loader([menu], current=None, last=None)
+    _patch_find(monkeypatch, {'标题': True})
+    result = find_screen_matches(ctx, MagicMock())
+    assert len(result) == 1
+    assert result[0].is_precise is True
+
+
+def test_no_id_mark_screen_only_enters_topn(monkeypatch) -> None:
+    """无 id_mark 画面精准永假,但参与命中数(可进 top_n)。"""
+    plain = _screen_info('无标识画面', [ScreenArea(area_name='p1', pc_rect=Rect(0, 0, 10, 10), text='p')])
+    ctx = MagicMock()
+    ctx.screen_loader = _make_loader([plain])
+    _patch_find(monkeypatch, {'p1': True})
+    result = find_screen_matches(ctx, MagicMock())
+    assert len(result) == 1
+    assert result[0].is_precise is False
+
+
+def test_bfs_traverses_goto_neighbors(monkeypatch) -> None:
+    """BFS 从 current 沿 goto_list 扩散到邻接画面(图不连通时兜底全量覆盖)。"""
+    a = _screen_info('A', [_id_mark_text_area('a_mark', 'a')])
+    a_area = ScreenArea(area_name='a_goto', pc_rect=Rect(0, 0, 10, 10), text='goto')
+    a_area.goto_list = ['B']
+    a.area_list.append(a_area)
+    b = _screen_info('B', [_id_mark_text_area('b_mark', 'b')])
+    ctx = MagicMock()
+    ctx.screen_loader = _make_loader([a, b], current='A')
+    _patch_find(monkeypatch, {'b_mark': True})   # A 的 a_mark 未中 → 沿 goto 到 B
+    result = find_screen_matches(ctx, MagicMock())
+    assert len(result) == 1
+    assert result[0].screen_name == 'B'
+    assert result[0].is_precise is True
+
+
+def test_precise_early_stop_returns_first_processed(monkeypatch) -> None:
+    """current 起的精准早停:两画面共享 id_mark 时,current 先处理即返(B 不会进 BFS)。
+
+    (精准早停使「共享 id_mark tie-break」实际不可达 —— 首个精准即返,不存在多精准排序。)
+    """
+    a = _screen_info('A', [_id_mark_text_area('shared', 'x')])
+    b = _screen_info('B', [_id_mark_text_area('shared', 'x')])
+    ctx = MagicMock()
+    ctx.screen_loader = _make_loader([a, b], current='A')
+    _patch_find(monkeypatch, {'shared': True})
+    result = find_screen_matches(ctx, MagicMock())
+    assert len(result) == 1
+    assert result[0].screen_name == 'A'   # current=A,BFS 从 A 起,A 首个精准即返
+
+
+def test_color_range_distinct_ocr_called_per_range(monkeypatch) -> None:
+    """两个不同 color_range 的 text area → OCR 各调一次(不同 color_range 缓存不复用)。
+
+    spec §2.5 性能论据:find_area_with_detail 默认 crop_first=False 走全图 OCR 缓存
+    复用,但缓存键含 color_range;不同 color_range 各触发一次全图 OCR。
+    """
+    area_a = ScreenArea(area_name='a', pc_rect=Rect(0, 0, 100, 50), text='x', lcs_percent=0.5,
+                        color_range=[[0, 0, 0], [100, 100, 100]])
+    area_b = ScreenArea(area_name='b', pc_rect=Rect(0, 0, 100, 50), text='y', lcs_percent=0.5,
+                        color_range=[[200, 200, 200], [255, 255, 255]])
+    screen = _screen_info('S', [area_a, area_b])
+    ctx = MagicMock()
+    ctx.screen_loader = _make_loader([screen])
+    ctx.ocr_service.get_ocr_result_list.return_value = []
+
+    find_screen_matches(ctx, MagicMock())
+
+    assert ctx.ocr_service.get_ocr_result_list.call_count == 2   # 不同 color_range 各一次
+
+
+def test_color_range_none_ocr_reuses_cache(monkeypatch) -> None:
+    """两个 color_range=None(相同)的 text area → OCR 只调一次(全图缓存复用契约)。
+
+    spec §2.5 性能论据根基:同 color_range + crop_first=False 时,ocr_service 内部
+    缓存命中、不重复全图 OCR。本测试用 side_effect 模拟该缓存:以 (color_range, crop_first)
+    为键,首次"实际跑 OCR"(计 1 次),同键后续命中缓存(不再计)。find_screen_matches
+    两次 find_area_with_detail 因 color_range 一致 → 真实 OCR 只 1 次。
+    """
+    area_a = ScreenArea(area_name='a', pc_rect=Rect(0, 0, 100, 50), text='x', lcs_percent=0.5)
+    area_b = ScreenArea(area_name='b', pc_rect=Rect(0, 0, 100, 50), text='y', lcs_percent=0.5)
+    screen = _screen_info('S', [area_a, area_b])
+    ctx = MagicMock()
+    ctx.screen_loader = _make_loader([screen])
+
+    real_call_keys: list[tuple] = []
+    cache: dict[tuple, list] = {}
+
+    def _ocr_with_cache(image, rect=None, color_range=None, crop_first=True):
+        key = (repr(color_range), crop_first)
+        if key not in cache:
+            real_call_keys.append(key)   # 仅首次"实际跑 OCR"计数
+            cache[key] = []
+        return cache[key]
+
+    ctx.ocr_service.get_ocr_result_list.side_effect = _ocr_with_cache
+
+    find_screen_matches(ctx, MagicMock())
+
+    assert len(real_call_keys) == 1   # 同 color_range=None → 缓存复用,真实 OCR 仅 1 次
+
+
+def test_scope_inactive_traverses_all_screens(monkeypatch) -> None:
+    """scope 未激活(active_screen_names=None)→ 全量遍历所有画面,均进候选。
+
+    spec ⑧:backend 语境 scope 恒不激活(loader.active_screen_names=None),
+    find_screen_matches 应遍历 loader.active_screen_info_list 全部画面。设多画面、
+    无 id_mark 命中(均进 top_n),断言全部进候选。
+    """
+    a = _screen_info('画面A', [ScreenArea(area_name='a1', pc_rect=Rect(0, 0, 10, 10), text='a')])
+    b = _screen_info('画面B', [ScreenArea(area_name='b1', pc_rect=Rect(0, 0, 10, 10), text='b')])
+    c = _screen_info('画面C', [ScreenArea(area_name='c1', pc_rect=Rect(0, 0, 10, 10), text='c')])
+    ctx = MagicMock()
+    ctx.screen_loader = _make_loader([a, b, c], current=None, last=None)
+    assert ctx.screen_loader.active_screen_names is None   # scope 未激活
+    _patch_find(monkeypatch, {'a1': True, 'b1': True, 'c1': True})
+
+    result = find_screen_matches(ctx, MagicMock(), top_n=10)
+
+    # 三画面均进候选(全量遍历,无 scope 过滤)
+    names = {m.screen_name for m in result}
+    assert names == {'画面A', '画面B', '画面C'}

--- a/test/one_dragon/envs/test_git_service.py
+++ b/test/one_dragon/envs/test_git_service.py
@@ -1,0 +1,131 @@
+"""测试 GitService 的拉取进度回调。"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from one_dragon.envs.git_service import GitService, _FetchProgressRemoteCallbacks
+
+
+class FakeRemote:
+
+    def __init__(self, progress_stats: SimpleNamespace):
+        self.name: str = 'origin'
+        self.progress_stats: SimpleNamespace = progress_stats
+        self.fetch_calls: list[dict[str, object]] = []
+
+    def fetch(
+        self,
+        refspecs: list[str] | None = None,
+        message: str | None = None,
+        callbacks: object | None = None,
+        prune: object | None = None,
+        proxy: bool | str | None = None,
+        depth: int = 0,
+    ) -> SimpleNamespace:
+        self.fetch_calls.append(
+            {
+                'refspecs': refspecs,
+                'message': message,
+                'callbacks': callbacks,
+                'prune': prune,
+                'proxy': proxy,
+                'depth': depth,
+            }
+        )
+        if callbacks is not None:
+            callbacks.transfer_progress(self.progress_stats)
+        return self.progress_stats
+
+
+class TestFetchProgressRemoteCallbacks:
+
+    def test_transfer_progress_maps_to_stage_range(self) -> None:
+        events: list[tuple[float, str]] = []
+        callbacks = _FetchProgressRemoteCallbacks(
+            lambda progress, message: events.append((progress, message)),
+            0.4,
+            0.6,
+        )
+
+        stats = SimpleNamespace(received_objects=3, total_objects=10, received_bytes=4096)
+        callbacks.transfer_progress(stats)
+
+        assert len(events) == 1
+        progress, message = events[0]
+        assert progress == pytest.approx(0.46)
+        assert message == '拉取对象 3/10'
+
+    def test_transfer_progress_falls_back_to_received_bytes(self) -> None:
+        events: list[tuple[float, str]] = []
+        callbacks = _FetchProgressRemoteCallbacks(
+            lambda progress, message: events.append((progress, message)),
+            0.2,
+            0.4,
+        )
+
+        stats = SimpleNamespace(received_objects=0, total_objects=0, received_bytes=3 * 1024 * 1024)
+        callbacks.transfer_progress(stats)
+
+        assert len(events) == 1
+        progress, message = events[0]
+        assert progress == pytest.approx(0.2)
+        assert message == '拉取对象 3.00 MB'
+
+    def test_transfer_progress_deduplicates_identical_messages(self) -> None:
+        events: list[tuple[float, str]] = []
+        callbacks = _FetchProgressRemoteCallbacks(
+            lambda progress, message: events.append((progress, message)),
+            0.2,
+            0.4,
+        )
+
+        stats = SimpleNamespace(received_objects=12, total_objects=12, received_bytes=2048)
+        callbacks.transfer_progress(stats)
+        callbacks.transfer_progress(stats)
+
+        assert events == [
+            (0.4, '拉取对象 12/12'),
+        ]
+
+
+class TestGitServiceFetchRemote:
+
+    @pytest.fixture
+    def git_service(self) -> GitService:
+        project_config = SimpleNamespace(
+            github_https_repository='https://example.com/repo.git',
+            gitee_https_repository='https://example.com/repo.git',
+        )
+        env_config = SimpleNamespace(
+            git_branch='main',
+            git_remote='origin',
+            is_personal_proxy=False,
+            personal_proxy='',
+        )
+        return GitService(project_config, env_config, repo_dir='.')
+
+    def test_fetch_remote_reports_progress_and_success(
+        self,
+        git_service: GitService,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        repo = SimpleNamespace(references={})
+        remote = FakeRemote(SimpleNamespace(received_objects=2, total_objects=4, received_bytes=2048))
+        events: list[tuple[float, str]] = []
+
+        monkeypatch.setattr(git_service, '_open_repo', lambda: repo)
+        monkeypatch.setattr(git_service, '_ensure_remote', lambda: remote)
+
+        success = git_service._fetch_remote(
+            lambda progress, message: events.append((progress, message)),
+            0.2,
+            0.4,
+        )
+
+        assert success is True
+        assert remote.fetch_calls[0]['depth'] == 1
+        assert remote.fetch_calls[0]['refspecs'] == ['+refs/heads/main:refs/remotes/origin/main']
+        assert events[0][0] == pytest.approx(0.3)
+        assert events[0][1] == '拉取对象 2/4'
+        assert events[-1] == (0.4, '获取远程代码成功')

--- a/test/one_dragon/envs/test_git_service.py
+++ b/test/one_dragon/envs/test_git_service.py
@@ -39,13 +39,18 @@ class FakeRemote:
 
 
 class TestFetchProgressRemoteCallbacks:
+    """测试 _FetchProgressRemoteCallbacks 的当前行为。
 
-    def test_transfer_progress_maps_to_stage_range(self) -> None:
+    注意：当前实现中 stage 映射已上移到 GitService._create_fetch_callbacks，
+    此处回调只接收 progress_callback，并直接传出原始进度（0.0~1.0）；
+    消息格式包含百分比，例如「拉取对象 3/10 (30%)」。
+    """
+
+    def test_transfer_progress_reports_object_progress_with_percentage(self) -> None:
         events: list[tuple[float, str]] = []
+        # 当前构造器只接收 progress_callback，不再接收 stage_start/stage_end
         callbacks = _FetchProgressRemoteCallbacks(
             lambda progress, message: events.append((progress, message)),
-            0.4,
-            0.6,
         )
 
         stats = SimpleNamespace(received_objects=3, total_objects=10, received_bytes=4096)
@@ -53,15 +58,14 @@ class TestFetchProgressRemoteCallbacks:
 
         assert len(events) == 1
         progress, message = events[0]
-        assert progress == pytest.approx(0.46)
-        assert message == '拉取对象 3/10'
+        # 不做 stage 映射，直接传 received/total 原始进度
+        assert progress == pytest.approx(0.3)
+        assert message == '拉取对象 3/10 (30%)'
 
     def test_transfer_progress_falls_back_to_received_bytes(self) -> None:
         events: list[tuple[float, str]] = []
         callbacks = _FetchProgressRemoteCallbacks(
             lambda progress, message: events.append((progress, message)),
-            0.2,
-            0.4,
         )
 
         stats = SimpleNamespace(received_objects=0, total_objects=0, received_bytes=3 * 1024 * 1024)
@@ -69,15 +73,14 @@ class TestFetchProgressRemoteCallbacks:
 
         assert len(events) == 1
         progress, message = events[0]
-        assert progress == pytest.approx(0.2)
+        # total_objects 为 0 时进度回退为 0.0，消息用 MB
+        assert progress == pytest.approx(0.0)
         assert message == '拉取对象 3.00 MB'
 
     def test_transfer_progress_deduplicates_identical_messages(self) -> None:
         events: list[tuple[float, str]] = []
         callbacks = _FetchProgressRemoteCallbacks(
             lambda progress, message: events.append((progress, message)),
-            0.2,
-            0.4,
         )
 
         stats = SimpleNamespace(received_objects=12, total_objects=12, received_bytes=2048)
@@ -85,7 +88,7 @@ class TestFetchProgressRemoteCallbacks:
         callbacks.transfer_progress(stats)
 
         assert events == [
-            (0.4, '拉取对象 12/12'),
+            (1.0, '拉取对象 12/12 (100%)'),
         ]
 
 
@@ -127,5 +130,5 @@ class TestGitServiceFetchRemote:
         assert remote.fetch_calls[0]['depth'] == 1
         assert remote.fetch_calls[0]['refspecs'] == ['+refs/heads/main:refs/remotes/origin/main']
         assert events[0][0] == pytest.approx(0.3)
-        assert events[0][1] == '拉取对象 2/4'
-        assert events[-1] == (0.4, '获取远程代码成功')
+        assert events[0][1] == '拉取对象 2/4 (50%)'
+        assert events[-1] == (0.4, '拉取远程代码成功')

--- a/test/one_dragon/test_code_sync_progress.py
+++ b/test/one_dragon/test_code_sync_progress.py
@@ -1,0 +1,195 @@
+from types import SimpleNamespace
+
+import one_dragon.devtools.python_launcher as python_launcher
+import one_dragon.envs.env_config as env_config_module
+import one_dragon.envs.git_service as git_service_module
+import one_dragon.envs.project_config as project_config_module
+import one_dragon.utils.i18_utils as i18_utils_module
+from one_dragon.launcher.runtime_launcher import RuntimeLauncher
+
+
+def test_git_service_transfer_progress_limits_transfer_messages(monkeypatch) -> None:
+    messages: list[tuple[float, str]] = []
+    callback = git_service_module._FetchProgressRemoteCallbacks(lambda progress, message: messages.append((progress, message)))
+    timestamps = iter([0.0, 0.1, 0.4])
+    monkeypatch.setattr(git_service_module.time, 'monotonic', lambda: next(timestamps))
+
+    callback.transfer_progress(SimpleNamespace(total_objects=10, received_objects=1, received_bytes=0))
+    callback.transfer_progress(SimpleNamespace(total_objects=10, received_objects=2, received_bytes=0))
+    callback.transfer_progress(SimpleNamespace(total_objects=10, received_objects=3, received_bytes=0))
+
+    assert messages == [
+        (0.1, '拉取对象 1/10 (10%)'),
+        (0.3, '拉取对象 3/10 (30%)'),
+    ]
+
+
+def test_git_service_transfer_progress_always_shows_final_100_percent(monkeypatch) -> None:
+    messages: list[tuple[float, str]] = []
+    callback = git_service_module._FetchProgressRemoteCallbacks(lambda progress, message: messages.append((progress, message)))
+    timestamps = iter([0.0, 0.1])
+    monkeypatch.setattr(git_service_module.time, 'monotonic', lambda: next(timestamps))
+
+    callback.transfer_progress(SimpleNamespace(total_objects=10, received_objects=1, received_bytes=0))
+    callback.transfer_progress(SimpleNamespace(total_objects=10, received_objects=10, received_bytes=0))
+
+    assert messages == [
+        (0.1, '拉取对象 1/10 (10%)'),
+        (1.0, '拉取对象 10/10 (100%)'),
+    ]
+
+
+def test_python_launcher_fetch_latest_code_passes_progress_callback(
+    monkeypatch,
+) -> None:
+    messages: list[tuple[str, str]] = []
+
+    class FakeGitService:
+
+        def __init__(self) -> None:
+            self.progress_callback = None
+
+        def fetch_latest_code(self, progress_callback=None):
+            self.progress_callback = progress_callback
+            progress_callback(0.421, '拉取对象 3/10 (30%)')
+            progress_callback(0.500, '检查运行环境兼容性')
+            return True, ''
+
+    git_service = FakeGitService()
+    ctx = SimpleNamespace(
+        env_config=SimpleNamespace(auto_update=True),
+        git_service=git_service,
+    )
+
+    monkeypatch.setattr(
+        python_launcher,
+        'print_message',
+        lambda message, level='INFO', flush=False: messages.append((level, message)),
+    )
+
+    python_launcher.fetch_latest_code(ctx)
+
+    assert git_service.progress_callback is not None
+    assert ('INFO', '拉取对象 3/10 (30%)') in messages
+    assert ('INFO', '检查运行环境兼容性') in messages
+    assert ('PASS', '代码更新完成') in messages
+
+
+def test_python_launcher_fetch_latest_code_silences_framework_console_log(
+    monkeypatch,
+) -> None:
+    configured: list[tuple[object, str | None, bool, bool]] = []
+
+    class FakeGitService:
+
+        def fetch_latest_code(self, progress_callback=None):
+            progress_callback(0.500, '检查运行环境兼容性')
+            return True, ''
+
+    messages: list[tuple[str, str]] = []
+    ctx = SimpleNamespace(
+        env_config=SimpleNamespace(auto_update=True),
+        git_service=FakeGitService(),
+    )
+
+    def _fake_configure_logger(logger, config):
+        configured.append(
+            (
+                logger,
+                config.log_file_path,
+                config.add_console_handler,
+                config.propagate,
+            )
+        )
+        return logger
+
+    monkeypatch.setattr(
+        python_launcher,
+        'configure_logger',
+        _fake_configure_logger,
+    )
+    monkeypatch.setattr(
+        python_launcher,
+        'print_message',
+        lambda message, level='INFO', flush=False: messages.append((level, message)),
+    )
+
+    python_launcher.fetch_latest_code(ctx)
+
+    assert configured
+    assert configured[0][0] is python_launcher.framework_log
+    assert configured[0][1] is not None
+    assert configured[0][2] is False
+    assert configured[0][3] is False
+    assert ('INFO', '检查运行环境兼容性') in messages
+
+
+def test_python_launcher_progress_callback_passes_stage_messages_through() -> None:
+    messages: list[tuple[str, str, bool]] = []
+
+    callback = python_launcher.create_git_progress_callback()
+    original_print_message = python_launcher.print_message
+    python_launcher.print_message = lambda message, level='INFO', flush=False: messages.append((level, message, flush))
+    try:
+        callback(0.2, '获取远程代码')
+        callback(0.5, '检查工作区状态')
+        callback(0.3, '拉取对象 3/10 (30%)')
+        callback(1.0, '拉取对象 10/10 (100%)')
+    finally:
+        python_launcher.print_message = original_print_message
+
+    assert messages == [
+        ('INFO', '获取远程代码', False),
+        ('INFO', '检查工作区状态', False),
+        ('INFO', '拉取对象 3/10 (30%)', True),
+        ('INFO', '拉取对象 10/10 (100%)', False),
+    ]
+
+
+def test_runtime_launcher_sync_code_uses_framework_log(monkeypatch) -> None:
+    messages: list[str] = []
+
+    class FakeEnvConfig:
+        auto_update = True
+
+    class FakeGitService:
+        instances: list['FakeGitService'] = []
+
+        def __init__(self, project_config, env_config) -> None:
+            self.project_config = project_config
+            self.env_config = env_config
+            self.progress_callback = None
+            FakeGitService.instances.append(self)
+
+        def check_repo_exists(self) -> bool:
+            return True
+
+        def fetch_latest_code(self, progress_callback=None):
+            self.progress_callback = progress_callback
+            progress_callback(0.3, '拉取对象 3/10 (30%)')
+            progress_callback(1.0, '拉取对象 10/10 (100%)')
+            return True, ''
+
+    print_calls: list[tuple[str, str, bool]] = []
+
+    monkeypatch.setattr(env_config_module, 'EnvConfig', FakeEnvConfig)
+    monkeypatch.setattr(git_service_module, 'GitService', FakeGitService)
+    monkeypatch.setattr(project_config_module, 'ProjectConfig', lambda: object())
+    monkeypatch.setattr(i18_utils_module, 'gt', lambda message: message)
+    monkeypatch.setattr('one_dragon.utils.log_utils.log.info', lambda message: messages.append(message))
+    monkeypatch.setattr(
+        'builtins.print',
+        lambda message, end='\n', flush=False: print_calls.append((message, end, flush)),
+    )
+
+    launcher = RuntimeLauncher('test', '1.0.0')
+    launcher._sync_code()
+
+    assert len(FakeGitService.instances) == 1
+    assert FakeGitService.instances[0].progress_callback is not None
+    assert '正在检查代码更新...' in messages
+    assert '拉取对象 3/10 (30%)' not in messages
+    assert '拉取对象 10/10 (100%)' in messages
+    assert print_calls[0] == ('拉取对象 3/10 (30%)', '\r', True)
+    assert print_calls[1] == (' ' * 120, '\r', True)
+    assert '代码更新检查完成' in messages

--- a/test/one_dragon/test_code_sync_progress.py
+++ b/test/one_dragon/test_code_sync_progress.py
@@ -57,7 +57,7 @@ def test_python_launcher_fetch_latest_code_passes_progress_callback(
 
     git_service = FakeGitService()
     ctx = SimpleNamespace(
-        env_config=SimpleNamespace(auto_update=True),
+        env_config=SimpleNamespace(auto_update_code=True),
         git_service=git_service,
     )
 
@@ -88,7 +88,7 @@ def test_python_launcher_fetch_latest_code_silences_framework_console_log(
 
     messages: list[tuple[str, str]] = []
     ctx = SimpleNamespace(
-        env_config=SimpleNamespace(auto_update=True),
+        env_config=SimpleNamespace(auto_update_code=True),
         git_service=FakeGitService(),
     )
 
@@ -150,7 +150,7 @@ def test_runtime_launcher_sync_code_uses_framework_log(monkeypatch) -> None:
     messages: list[str] = []
 
     class FakeEnvConfig:
-        auto_update = True
+        auto_update_code = True
 
     class FakeGitService:
         instances: list['FakeGitService'] = []

--- a/test/one_dragon/test_gpu_inference_serialization.py
+++ b/test/one_dragon/test_gpu_inference_serialization.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import sys
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from types import ModuleType, SimpleNamespace
+
+import numpy as np
+import pytest
+
+# src 入 path 由主仓 pyproject 的 [tool.pytest.ini_options] pythonpath=['src'] 接管，
+# 无需在此手动 sys.path.insert。
+
+from one_dragon.base.matcher.ocr.onnx_ocr_matcher import OnnxOcrMatcher
+from one_dragon.utils import gpu_executor
+
+
+class ConcurrencyProbe:
+
+    def __init__(self, target_parallelism: int = 2):
+        self.target_parallelism = target_parallelism
+        self.active = 0
+        self.max_active = 0
+        self.lock = threading.Lock()
+        self.parallel_event = threading.Event()
+
+    def enter(self) -> None:
+        with self.lock:
+            self.active += 1
+            self.max_active = max(self.max_active, self.active)
+            if self.active >= self.target_parallelism:
+                self.parallel_event.set()
+
+        self.parallel_event.wait(timeout=0.2)
+        time.sleep(0.02)
+
+        with self.lock:
+            self.active -= 1
+
+
+class FakeSession:
+
+    def __init__(
+            self,
+            probe: ConcurrencyProbe,
+            providers: list[str] | None = None,
+            fail_provider_lookup: bool = False,
+    ):
+        self.probe = probe
+        self.providers = providers or ["DmlExecutionProvider"]
+        self.fail_provider_lookup = fail_provider_lookup
+
+    def get_providers(self) -> list[str]:
+        if self.fail_provider_lookup:
+            raise RuntimeError("provider lookup failed")
+        return self.providers
+
+    def run(self, output_names, input_feed):
+        self.probe.enter()
+        return [np.zeros((1, 1), dtype=np.float32)]
+
+
+def test_create_onnx_session_serializes_dml_factories():
+    probe = ConcurrencyProbe()
+
+    def create_session():
+        probe.enter()
+        return object()
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        future_list = [
+            executor.submit(
+                gpu_executor.create_onnx_session,
+                create_session,
+                ["DmlExecutionProvider"],
+            )
+            for _ in range(2)
+        ]
+        for future in future_list:
+            future.result(timeout=2)
+
+    assert probe.max_active == 1
+
+
+def test_run_session_serializes_dml_sessions():
+    probe = ConcurrencyProbe()
+    session = FakeSession(probe)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        future_list = [
+            executor.submit(gpu_executor.run_session, session, ["output"], {"input": 1})
+            for _ in range(2)
+        ]
+        for future in future_list:
+            future.result(timeout=2)
+
+    assert probe.max_active == 1
+
+
+def test_run_session_serializes_when_provider_lookup_fails():
+    probe = ConcurrencyProbe()
+    session = FakeSession(probe, fail_provider_lookup=True)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        future_list = [
+            executor.submit(gpu_executor.run_session, session, ["output"], {"input": 1})
+            for _ in range(2)
+        ]
+        for future in future_list:
+            future.result(timeout=2)
+
+    assert probe.max_active == 1
+
+
+def test_run_session_does_not_serialize_cpu_sessions():
+    probe = ConcurrencyProbe()
+    session = FakeSession(probe, providers=["CPUExecutionProvider"])
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        future_list = [
+            executor.submit(gpu_executor.run_session, session, ["output"], {"input": 1})
+            for _ in range(2)
+        ]
+        for future in future_list:
+            future.result(timeout=2)
+
+    assert probe.max_active >= 2
+
+
+def test_ocr_init_model_uses_lock_for_concurrent_calls(monkeypatch):
+    init_count = 0
+    download_count = 0
+    count_lock = threading.Lock()
+
+    class FakeOcrRuntime:
+
+        def __init__(self, **kwargs):
+            nonlocal init_count
+            time.sleep(0.05)
+            with count_lock:
+                init_count += 1
+
+    fake_module = ModuleType("onnxocr.onnx_paddleocr")
+    fake_module.ONNXPaddleOcr = FakeOcrRuntime
+    monkeypatch.setitem(sys.modules, "onnxocr.onnx_paddleocr", fake_module)
+
+    matcher = object.__new__(OnnxOcrMatcher)
+    matcher._ocr_param = SimpleNamespace(to_dict=lambda: {})
+    matcher._model = None
+    matcher._init_lock = threading.Lock()
+
+    def download(**kwargs):
+        nonlocal download_count
+        time.sleep(0.05)
+        with count_lock:
+            download_count += 1
+        return True
+
+    matcher.download = download
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        future_list = [executor.submit(matcher.init_model) for _ in range(2)]
+        for future in future_list:
+            assert future.result(timeout=2)
+
+    assert download_count == 1
+    assert init_count == 1
+
+
+def test_ocr_init_model_failure_releases_lock(monkeypatch):
+    fake_module = ModuleType("onnxocr.onnx_paddleocr")
+    fake_module.ONNXPaddleOcr = object
+    monkeypatch.setitem(sys.modules, "onnxocr.onnx_paddleocr", fake_module)
+
+    matcher = object.__new__(OnnxOcrMatcher)
+    matcher._ocr_param = SimpleNamespace(to_dict=lambda: {})
+    matcher._model = None
+    matcher._init_lock = threading.Lock()
+    matcher.download = lambda **kwargs: False
+
+    assert not matcher.init_model()
+    assert matcher._init_lock.acquire(blocking=False)
+    matcher._init_lock.release()
+
+
+def test_onnx_paddleocr_ocr_reraises_inference_errors(monkeypatch):
+    from onnxocr.onnx_paddleocr import ONNXPaddleOcr
+
+    monkeypatch.setattr(
+        "one_dragon.utils.debug_utils.save_debug_image",
+        lambda **kwargs: None,
+    )
+
+    class FailingOcr(ONNXPaddleOcr):
+
+        def __init__(self):
+            self.use_angle_cls = False
+
+        def __call__(self, img, cls=True):
+            raise RuntimeError("ocr exploded")
+
+    image = np.zeros((16, 16, 3), dtype=np.uint8)
+    with pytest.raises(RuntimeError, match="ocr exploded"):
+        FailingOcr().ocr(image, det=True, rec=True, cls=False)

--- a/test/zzz_od/auto_battle/test_cv_timeout_control.py
+++ b/test/zzz_od/auto_battle/test_cv_timeout_control.py
@@ -1,0 +1,341 @@
+# -*- coding: utf-8 -*-
+"""
+CV流水线超时控制功能专项测试
+"""
+
+import os
+import unittest
+import time
+import numpy as np
+from unittest.mock import MagicMock, patch
+
+# 尝试导入项目依赖类
+IMPORTS_AVAILABLE = False
+try:
+    from one_dragon.base.cv_process.cv_pipeline import CvPipeline
+    from one_dragon.base.cv_process.cv_step import CvStep, CvPipelineContext
+    from one_dragon.base.cv_process.cv_service import CvService
+    from zzz_od.auto_battle.target_state.target_state_checker import TargetStateChecker
+    from zzz_od.context.zzz_context import ZContext
+    from zzz_od.game_data.target_state import DetectionTask, TargetStateDef, TargetCheckWay
+    IMPORTS_AVAILABLE = True
+except ImportError:
+    # 依赖不可用时，IMPORTS_AVAILABLE保持False
+    pass
+
+
+class TestCvTimeoutControl(unittest.TestCase):
+    """CV流水线超时控制功能测试类"""
+
+    @classmethod
+    def setUpClass(cls):
+        """测试类初始化，检查依赖是否可用"""
+        if not IMPORTS_AVAILABLE:
+            raise unittest.SkipTest("因缺少核心CV模块而跳过此测试套件")
+
+    def setUp(self):
+        """测试初始化"""
+        # 创建一个简单的测试图像
+        self.test_image = np.zeros((100, 100, 3), dtype=np.uint8)
+
+        # 创建模拟的上下文
+        self.mock_context = MagicMock()
+        self.mock_context.check_timeout.return_value = False
+        self.mock_context.is_success.return_value = True
+
+    def tearDown(self):
+        """测试清理"""
+        pass
+
+    def test_cv_pipeline_context_timeout_check_no_timeout(self):
+        """测试CvPipelineContext在无超时设置时的行为"""
+        context = CvPipelineContext(self.test_image)
+        # 默认没有超时设置，应该返回False
+        self.assertFalse(context.check_timeout())
+
+    def test_cv_pipeline_context_timeout_check_with_timeout_not_expired(self):
+        """测试CvPipelineContext在超时未到期时的行为"""
+        start_time = time.time()
+        context = CvPipelineContext(self.test_image, start_time=start_time, timeout=2.0)
+        # 超时未到期，应该返回False
+        self.assertFalse(context.check_timeout())
+
+    def test_cv_pipeline_context_timeout_check_with_timeout_expired(self):
+        """测试CvPipelineContext在超时到期时的行为"""
+        start_time = time.time() - 2.0  # 2秒前开始
+        context = CvPipelineContext(self.test_image, start_time=start_time, timeout=1.0)
+        # 超时已到期，应该返回True
+        self.assertTrue(context.check_timeout())
+
+    def test_cv_pipeline_execute_with_no_timeout(self):
+        """测试CvPipeline在无超时设置时的执行"""
+        pipeline = CvPipeline()
+        context = pipeline.execute(self.test_image)
+        self.assertTrue(context.success)
+        self.assertIsNone(context.error_str)
+
+    def test_cv_pipeline_execute_with_timeout_not_expired(self):
+        """测试CvPipeline在超时未到期时的执行"""
+        pipeline = CvPipeline()
+        start_time = time.time()
+        context = pipeline.execute(self.test_image, start_time=start_time, timeout=2.0)
+        self.assertTrue(context.success)
+        self.assertIsNone(context.error_str)
+
+    def test_cv_pipeline_execute_with_timeout_expired(self):
+        """测试CvPipeline在超时到期时的执行"""
+        # 创建一个带有耗时步骤的流水线
+        pipeline = CvPipeline()
+
+        class SlowStep(CvStep):
+            def __init__(self):
+                super().__init__("slow_step")
+
+            def execute(self, context):
+                # 模拟耗时操作
+                time.sleep(0.1)
+
+        # 添加几个慢步骤
+        for _ in range(5):
+            pipeline.steps.append(SlowStep())
+
+        # 设置一个很短的超时时间
+        start_time = time.time() - 2.0  # 2秒前开始
+        context = pipeline.execute(self.test_image, start_time=start_time, timeout=1.0)
+
+        # 应该超时并失败
+        self.assertFalse(context.success)
+        self.assertIsNotNone(context.error_str)
+        self.assertIn("超时", context.error_str)
+
+    def test_cv_pipeline_execute_steps_timeout_check(self):
+        """测试CvPipeline在执行步骤过程中检查超时"""
+        pipeline = CvPipeline()
+
+        class SlowStep(CvStep):
+            def __init__(self, name):
+                super().__init__(name)
+                self.execute_count = 0
+
+            def execute(self, context):
+                self.execute_count += 1
+                # 模拟耗时操作
+                time.sleep(0.05)  # 50ms延迟
+
+        # 添加步骤
+        step1 = SlowStep("step1")
+        step2 = SlowStep("step2")
+        step3 = SlowStep("step3")
+
+        pipeline.steps = [step1, step2, step3]
+
+        # 设置一个很短的超时时间（小于所有步骤的总执行时间）
+        start_time = time.time()
+        context = pipeline.execute(self.test_image, start_time=start_time, timeout=0.08)  # 80ms超时
+
+        # 应该在前两个步骤后超时，第三个步骤不应执行
+        self.assertEqual(step1.execute_count, 1)
+        self.assertEqual(step2.execute_count, 1)
+        # step3可能不会执行，但由于执行速度快，我们检查总执行时间
+
+        # 应该超时并失败
+        self.assertFalse(context.success)
+        self.assertIsNotNone(context.error_str)
+        self.assertIn("超时", context.error_str)
+
+        # 验证总执行时间超过了超时限制
+        self.assertGreater(context.total_execution_time, 80)  # 应该超过80ms
+
+    def test_cv_service_run_pipeline_with_timeout(self):
+        """测试CvService运行流水线时的超时控制"""
+        # 创建模拟的od_ctx
+        mock_od_ctx = MagicMock()
+        mock_od_ctx.ocr = MagicMock()
+        mock_od_ctx.template_loader = MagicMock()
+        service = CvService(od_ctx=mock_od_ctx)
+        start_time = time.time() - 2.0  # 2秒前开始
+
+        # 创建一个简单的测试流水线
+        class TestPipeline(CvPipeline):
+            def __init__(self):
+                super().__init__()
+                self.steps = [CvStep("test_step")]
+
+        # 使用patch模拟load_pipeline方法返回我们的测试流水线
+        # 只有当CvService有load_pipeline方法时才进行patch
+        if hasattr(service, 'load_pipeline'):
+            with patch.object(service, 'load_pipeline', return_value=TestPipeline()):
+                context = service.run_pipeline(
+                    "test_pipeline",
+                    self.test_image,
+                    start_time=start_time,
+                    timeout=1.0
+                )
+        else:
+            # 如果没有load_pipeline方法，直接调用run_pipeline
+            context = service.run_pipeline(
+                "test_pipeline",
+                self.test_image,
+                start_time=start_time,
+                timeout=1.0
+            )
+
+        # 无论走哪个分支，都必须验证超时行为
+        # 由于超时已到期，应该失败
+        self.assertFalse(context.success)
+        self.assertIsNotNone(context.error_str)
+        self.assertIn("超时", context.error_str)
+
+    def test_target_state_checker_run_task_with_timeout(self):
+        """测试TargetStateChecker运行任务时的超时控制"""
+        # 创建模拟上下文
+        mock_ctx = MagicMock()
+        mock_ctx.cv_service = MagicMock()
+
+        # 模拟一个已经超时的上下文
+        mock_timeout_context = MagicMock()
+        mock_timeout_context.success = False
+        mock_timeout_context.error_str = "流水线执行超时 (限制 1.0 秒)"
+        mock_ctx.cv_service.run_pipeline.return_value = mock_timeout_context
+
+        checker = TargetStateChecker(mock_ctx)
+
+        # 创建一个测试任务
+        task = DetectionTask(
+            task_id="test_task",
+            pipeline_name="test_pipeline",
+            state_definitions=[
+                TargetStateDef("test_state", TargetCheckWay.CONTOUR_COUNT_IN_RANGE, {"min_count": 1})
+            ]
+        )
+
+        # 运行任务
+        cv_result, _ = checker.run_task(self.test_image, task)
+
+        # 验证结果
+        self.assertFalse(cv_result.success)
+        self.assertIsNotNone(cv_result.error_str)
+        self.assertIn("超时", cv_result.error_str)
+
+    def test_target_state_checker_run_task_without_timeout(self):
+        """测试TargetStateChecker运行任务时无超时的情况"""
+        # 创建模拟上下文
+        mock_ctx = MagicMock()
+        mock_ctx.cv_service = MagicMock()
+
+        # 模拟一个成功的上下文
+        mock_success_context = MagicMock()
+        mock_success_context.success = True
+        mock_success_context.error_str = None
+        mock_ctx.cv_service.run_pipeline.return_value = mock_success_context
+
+        checker = TargetStateChecker(mock_ctx)
+
+        # 创建一个测试任务
+        task = DetectionTask(
+            task_id="test_task",
+            pipeline_name="test_pipeline",
+            state_definitions=[
+                TargetStateDef("test_state", TargetCheckWay.CONTOUR_COUNT_IN_RANGE, {"min_count": 1})
+            ]
+        )
+
+        # 运行任务
+        cv_result, _ = checker.run_task(self.test_image, task)
+
+        # 验证结果
+        self.assertTrue(cv_result.success)
+        self.assertIsNone(cv_result.error_str)
+
+    def test_cv_pipeline_context_timeout_with_zero_timeout(self):
+        """测试CvPipelineContext在超时时间为0时的行为"""
+        start_time = time.time() - 0.1  # 0.1秒前开始
+        context = CvPipelineContext(self.test_image, start_time=start_time, timeout=0.0)
+        # 超时时间已到期，应该返回True
+        self.assertTrue(context.check_timeout())
+
+    def test_cv_pipeline_context_timeout_with_none_timeout(self):
+        """测试CvPipelineContext在超时时间为None时的行为"""
+        start_time = time.time() - 10.0  # 10秒前开始
+        context = CvPipelineContext(self.test_image, start_time=start_time, timeout=None)
+        # 没有超时限制，应该返回False
+        self.assertFalse(context.check_timeout())
+
+    def test_cv_pipeline_execute_with_multiple_steps_and_timeout(self):
+        """测试CvPipeline在执行多个步骤时的超时控制"""
+        pipeline = CvPipeline()
+
+        class QuickStep(CvStep):
+            def __init__(self, name):
+                super().__init__(name)
+                self.execute_count = 0
+
+            def execute(self, context):
+                self.execute_count += 1
+                # 模拟快速执行
+                pass
+
+        # 添加多个步骤
+        steps = [QuickStep(f"step_{i}") for i in range(10)]
+        pipeline.steps = steps
+
+        # 设置一个合理的超时时间
+        start_time = time.time()
+        context = pipeline.execute(self.test_image, start_time=start_time, timeout=1.0)
+
+        # 所有步骤都应该执行
+        for step in steps:
+            self.assertEqual(step.execute_count, 1)
+
+        # 应该成功执行
+        self.assertTrue(context.success)
+        self.assertIsNone(context.error_str)
+
+    @unittest.skipUnless(os.getenv("RUN_INTEGRATION_TESTS") == "1", "跳过集成测试：设置 RUN_INTEGRATION_TESTS=1 以启用")
+    def test_async_task_timeout_control(self):
+        """测试异步任务的超时控制"""
+        # 创建模拟的自动战斗目标上下文
+        try:
+            from zzz_od.auto_battle.auto_battle_target_context import AutoBattleTargetContext
+            from zzz_od.context.zzz_context import ZContext
+            from one_dragon.base.conditional_operation.operator import ConditionalOperator
+
+            # 创建真实上下文
+            ctx = ZContext()
+            # 尝试不同的初始化方法
+            try:
+                ctx.init_by_config()
+            except AttributeError:
+                # 如果没有init_by_config方法，尝试其他方法
+                pass
+
+            target_context = AutoBattleTargetContext(ctx)
+
+            # 创建一个模拟的自动操作
+            auto_op = MagicMock()
+            auto_op.is_running = True
+            auto_op.batch_update_states = MagicMock()
+
+            target_context.init_battle_target_context(auto_op, 0, 0)
+
+            # 修改异步任务的超时时间，用于测试
+            for task in target_context.tasks:
+                if task.task_id == "boss_stun_by_length":
+                    task.interval = 0.1  # 设置较短的间隔
+
+            # 运行一次检测
+            target_context.run_all_checks(self.test_image, time.time())
+
+            # 验证batch_update_states被调用
+            self.assertTrue(auto_op.batch_update_states.called)
+
+        except ImportError:
+            # 如果无法导入真实类，跳过这个测试
+            self.skipTest("无法导入必要的类，跳过异步任务超时测试")
+        except Exception as e:
+            # 如果初始化失败，跳过这个测试
+            self.skipTest(f"初始化失败: {e}，跳过异步任务超时测试")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/zzz_od/backend/conftest.py
+++ b/test/zzz_od/backend/conftest.py
@@ -1,0 +1,20 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from zzz_od.backend.backend_context import RunSlot
+
+
+@pytest.fixture
+def mock_ctx():
+    """mock ZContext:run_context 可控,不依赖真实游戏/模型。"""
+    ctx = MagicMock(name='ZContext')
+    ctx.run_context.start_running.return_value = True
+    ctx.run_context.stop_running.return_value = None
+    ctx.current_instance_idx = 0
+    return ctx
+
+
+@pytest.fixture
+def slot(mock_ctx):
+    return RunSlot(mock_ctx)

--- a/test/zzz_od/backend/test_backend_context.py
+++ b/test/zzz_od/backend/test_backend_context.py
@@ -1,0 +1,237 @@
+"""ZzzBackendContext 生命周期与就绪校验的单元测试。
+
+测试使用 MagicMock 伪造 ZContext，避免触发真实的 onnx 模型加载。
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from zzz_od.backend.backend_context import BackendNotReadyError, ZzzBackendContext
+
+
+def _backend(ready: bool = True, controller: MagicMock | None = None) -> ZzzBackendContext:
+    """构造一个使用伪造 ctx 的 ZzzBackendContext。
+
+    Args:
+        ready: ctx.ready_for_application 的取值，默认 True。
+        controller: ctx.controller 的取值，默认 None。
+
+    Returns:
+        绑定了伪造 ctx 的 ZzzBackendContext 实例。
+    """
+    ctx = MagicMock()
+    ctx.ready_for_application = ready
+    ctx.controller = controller
+    return ZzzBackendContext(ctx)
+
+
+@pytest.mark.asyncio
+async def test_start_runs_init_in_thread() -> None:
+    """start() 应当在线程池中调用 ctx.init() 完成初始化。"""
+    ctx = MagicMock()
+    backend = ZzzBackendContext(ctx)
+    await backend.start()
+    ctx.init.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_shutdown_runs_after_app_shutdown_in_thread() -> None:
+    """shutdown() 应当在线程池中调用 ctx.after_app_shutdown() 释放资源。"""
+    ctx = MagicMock()
+    backend = ZzzBackendContext(ctx)
+    await backend.shutdown()
+    ctx.after_app_shutdown.assert_called_once()
+
+
+def test_ensure_ready_raises_when_not_ready() -> None:
+    """ctx 未就绪时，_ensure_ready() 应抛出 BackendNotReadyError。"""
+    backend = _backend(ready=False)
+    with pytest.raises(BackendNotReadyError):
+        backend._ensure_ready()
+
+
+def test_check_window_returns_status_no_rect() -> None:
+    game_win = MagicMock(
+        win_title="绝区零", is_win_valid=True, is_win_active=False, is_win_scale=True, win_rect=None
+    )
+    backend = _backend(ready=True, controller=MagicMock(game_win=game_win))
+    status = backend.check_window()
+    assert status.win_title == "绝区零"
+    assert status.is_win_valid is True
+    assert status.x is None
+
+
+def test_check_window_with_rect() -> None:
+    rect = MagicMock(x1=1, y1=2, width=3, height=4)
+    game_win = MagicMock(win_title="t", is_win_valid=True, is_win_active=True, is_win_scale=True, win_rect=rect)
+    backend = _backend(ready=True, controller=MagicMock(game_win=game_win))
+    status = backend.check_window()
+    assert (status.x, status.y, status.width, status.height) == (1, 2, 3, 4)
+
+
+def test_capture_returns_image() -> None:
+    controller = MagicMock()
+    controller.is_game_window_ready = True
+    fake_img = object()
+    controller.get_screenshot.return_value = fake_img
+    backend = _backend(ready=True, controller=controller)
+    assert backend.capture() is fake_img
+    controller.get_screenshot.assert_called_once_with(independent=False)
+
+
+def test_capture_raises_when_window_not_ready() -> None:
+    controller = MagicMock()
+    controller.is_game_window_ready = False
+    backend = _backend(ready=True, controller=controller)
+    with pytest.raises(BackendNotReadyError):
+        backend.capture()
+
+
+def test_analyze_maps_ocr_results() -> None:
+    r1 = MagicMock(data="体力", x=1, y=2, w=3, h=4)
+    r2 = MagicMock(data="设定", x=5, y=6, w=7, h=8)
+    controller = MagicMock()
+    controller.is_game_window_ready = True
+    controller.get_screenshot.return_value = object()
+    ctx = MagicMock()
+    ctx.ready_for_application = True
+    ctx.controller = controller
+    ctx.ocr_service.get_ocr_result_list.return_value = [r1, r2]
+    backend = ZzzBackendContext(ctx)
+    result = backend.analyze()
+    assert result.success is True
+    assert [t.text for t in result.ocr_texts] == ["体力", "设定"]
+    assert result.ocr_texts[0].width == 3
+
+
+def test_analyze_returns_error_when_screenshot_none() -> None:
+    controller = MagicMock()
+    controller.is_game_window_ready = True
+    controller.get_screenshot.return_value = None
+    backend = _backend(ready=True, controller=controller)
+    result = backend.analyze()
+    assert result.success is False
+    assert "截图失败" in (result.error or "")
+
+
+def test_analyze_returns_screens_and_writes_back_on_precise(monkeypatch) -> None:
+    """analyze 精准命中 → 返回 screens[0].is_precise=True,并回写 current_screen_name。"""
+    import zzz_od.backend.backend_context as bc
+    from one_dragon.base.screen.screen_match import ScreenMatch
+
+    controller = MagicMock()
+    controller.is_game_window_ready = True
+    controller.get_screenshot.return_value = MagicMock()
+    backend = _backend(ready=True, controller=controller)
+
+    # mock find_screen_matches 返精准
+    precise = ScreenMatch(screen_name='菜单', is_precise=True, areas=[])
+    monkeypatch.setattr(bc, 'find_screen_matches', lambda ctx, screen, top_n=5: [precise])
+    # mock ocr_service 返空(ocr_texts 走全图 OCR)
+    backend.ctx.ocr_service.get_ocr_result_list.return_value = []
+
+    result = backend.analyze()
+    assert result.success is True
+    assert len(result.screens) == 1
+    assert result.screens[0].is_precise is True
+    # 回写
+    backend.ctx.screen_loader.update_current_screen_name.assert_called_once_with('菜单')
+
+
+def test_analyze_no_precise_does_not_write_back(monkeypatch) -> None:
+    """analyze 无精准(模糊 top_n)→ 不回写 current_screen_name。"""
+    import zzz_od.backend.backend_context as bc
+    from one_dragon.base.screen.screen_match import ScreenMatch
+
+    controller = MagicMock()
+    controller.is_game_window_ready = True
+    controller.get_screenshot.return_value = MagicMock()
+    backend = _backend(ready=True, controller=controller)
+
+    fuzzy = ScreenMatch(screen_name='某画面', is_precise=False, areas=[])
+    monkeypatch.setattr(bc, 'find_screen_matches', lambda ctx, screen, top_n=5: [fuzzy])
+    backend.ctx.ocr_service.get_ocr_result_list.return_value = []
+
+    result = backend.analyze()
+    assert result.success is True
+    assert result.screens[0].is_precise is False
+    backend.ctx.screen_loader.update_current_screen_name.assert_not_called()
+
+
+def test_analyze_exception_no_writeback(monkeypatch) -> None:
+    """匹配中途异常 → success=False, screens=[], 不回写。"""
+    import zzz_od.backend.backend_context as bc
+
+    controller = MagicMock()
+    controller.is_game_window_ready = True
+    controller.get_screenshot.return_value = MagicMock()
+    backend = _backend(ready=True, controller=controller)
+
+    def boom(ctx, screen, top_n=5):
+        raise RuntimeError('ocr boom')
+    monkeypatch.setattr(bc, 'find_screen_matches', boom)
+
+    result = backend.analyze()
+    assert result.success is False
+    assert result.screens == []
+    assert result.error is not None
+    backend.ctx.screen_loader.update_current_screen_name.assert_not_called()
+
+
+def test_start_run_delegates_to_run_slot() -> None:
+    """start_run 应委托 run_slot._start_run，返回 (ok, future) 元组。
+
+    覆盖旧的 enter_game 用例：不再有同步 enter_game 方法，运行由
+    run_slot 异步派发；此处直接 mock run_slot，验证透传与返回结构。
+    """
+    from concurrent.futures import Future
+
+    backend = _backend(ready=True)
+    fut: Future = Future()
+    fut.set_result(object())
+    backend.run_slot = MagicMock()
+    backend.run_slot._start_run.return_value = (True, fut)
+
+    def _factory(_ctx: object) -> object:
+        return object()
+
+    ok, future = backend.start_run("mcp", _factory)
+    assert ok is True
+    assert future is fut
+    backend.run_slot._start_run.assert_called_once_with("mcp", _factory)
+
+
+def test_query_status_delegates_to_run_slot() -> None:
+    """query_status 应委托 run_slot._query_status 返回 RunStatusResult。"""
+    from zzz_od.backend.schemas import RunStatusResult
+
+    expected = RunStatusResult(state="idle", source=None, app=None,
+                               started_at=None, duration_seconds=None)
+    backend = _backend(ready=True)
+    backend.run_slot = MagicMock()
+    backend.run_slot._query_status.return_value = expected
+
+    assert backend.query_status() is expected
+    backend.run_slot._query_status.assert_called_once()
+
+
+def test_stop_delegates_to_run_slot() -> None:
+    """stop 应封装 run_slot._stop，无运行时返回 {stopped: False, error}。"""
+    backend = _backend(ready=True)
+    backend.run_slot = MagicMock()
+    backend.run_slot._stop.return_value = (False, None)
+
+    assert backend.stop() == {"stopped": False, "error": "当前无运行"}
+    backend.run_slot._stop.assert_called_once()
+
+
+def test_close_game_delegates() -> None:
+    """close_game 应委托 controller.close_game()。"""
+    controller = MagicMock()
+    controller.is_game_window_ready = True
+    controller.close_game.return_value = None
+    backend = _backend(ready=True, controller=controller)
+    msg = backend.close_game()
+    controller.close_game.assert_called_once()
+    assert msg == '已发送关闭游戏信号,可用 check_game_window 验证'

--- a/test/zzz_od/backend/test_close_game.py
+++ b/test/zzz_od/backend/test_close_game.py
@@ -1,0 +1,33 @@
+"""ZzzBackendContext.close_game() 的单元测试(独立仓)。"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from zzz_od.backend.backend_context import BackendNotReadyError, ZzzBackendContext
+
+
+@pytest.fixture
+def mock_ctx_game_ready():
+    """游戏就绪的 mock ZContext(显式设字段,不依赖 MagicMock 默认 truthy)。"""
+    ctx = MagicMock(name='ZContext')
+    ctx.ready_for_application = True
+    ctx.controller.is_game_window_ready = True
+    ctx.controller.close_game.return_value = None
+    return ctx
+
+
+def test_close_game_delegates_and_returns_text(mock_ctx_game_ready):
+    """close_game 应委托 controller.close_game() 并返回约定文案。"""
+    backend = ZzzBackendContext(mock_ctx_game_ready)
+    msg = backend.close_game()
+    mock_ctx_game_ready.controller.close_game.assert_called_once()
+    assert msg == '已发送关闭游戏信号,可用 check_game_window 验证'
+
+
+def test_close_game_window_not_ready_raises(mock_ctx_game_ready):
+    """游戏窗口未就绪时,close_game 应抛 BackendNotReadyError。"""
+    mock_ctx_game_ready.controller.is_game_window_ready = False
+    backend = ZzzBackendContext(mock_ctx_game_ready)
+    with pytest.raises(BackendNotReadyError):
+        backend.close_game()

--- a/test/zzz_od/backend/test_entry_server.py
+++ b/test/zzz_od/backend/test_entry_server.py
@@ -1,0 +1,40 @@
+"""后端服务入口（``create_app`` 装配）的单元测试。
+
+通过 ``MagicMock`` 伪造 backend（不真启动 uvicorn），只校验 ``create_app``
+是否把 MCP ``/mcp`` 端点与 ``/game/*`` custom_route 同进程挂到同一 Starlette app。
+``app.routes`` 可能含 ``Mount``，因此递归收集子路由的 ``path``。
+"""
+
+from typing import Any
+from unittest.mock import MagicMock
+
+from zzz_od.backend.entry.server import create_app
+
+
+def _collect_paths(routes: list[Any]) -> list[str]:
+    """递归收集 Starlette 路由（含 ``Mount`` 子路由）的 ``path``。
+
+    Args:
+        routes: ``app.routes`` 或某 ``Mount`` 的 ``routes`` 列表。
+
+    Returns:
+        所有非空 ``path`` 字符串列表。
+    """
+    paths: list[str] = []
+    for r in routes:
+        p = getattr(r, "path", None)
+        if p:
+            paths.append(p)
+        sub = getattr(r, "routes", None)
+        if sub:
+            paths.extend(_collect_paths(sub))
+    return paths
+
+
+def test_create_app_mounts_mcp_and_game_routes() -> None:
+    """``create_app`` 应在同一 app 上同时挂载 ``/game/*`` 与 ``mcp`` 端点。"""
+    backend = MagicMock()
+    app = create_app(backend)
+    paths = _collect_paths(app.routes)
+    assert any("/game/window" in p for p in paths)
+    assert any("mcp" in p for p in paths)

--- a/test/zzz_od/backend/test_http_routes.py
+++ b/test/zzz_od/backend/test_http_routes.py
@@ -60,3 +60,11 @@ def test_handle_game_status():
 def test_handle_game_stop():
     resp = asyncio.run(routes_mod.handle_game_stop(_mock_backend(), _FakeRequest({})))
     assert resp.status_code == 200
+
+
+def test_handle_game_close_ok():
+    backend = _mock_backend()
+    backend.close_game.return_value = '已发送关闭游戏信号,可用 check_game_window 验证'
+    resp = asyncio.run(routes_mod.handle_game_close(backend, _FakeRequest({})))
+    assert resp.status_code == 200
+    assert json.loads(resp.body)['result'] == '已发送关闭游戏信号,可用 check_game_window 验证'

--- a/test/zzz_od/backend/test_http_routes.py
+++ b/test/zzz_od/backend/test_http_routes.py
@@ -1,0 +1,62 @@
+import asyncio
+import json
+from concurrent.futures import Future
+from dataclasses import dataclass
+from unittest.mock import MagicMock
+
+from one_dragon.base.operation.operation_base import OperationResult
+from zzz_od.backend.http import routes as routes_mod
+from zzz_od.backend.schemas import RunStatusResult
+
+
+@dataclass
+class _FakeRequest:
+    query_params: dict
+
+    async def json(self) -> dict:
+        return {}
+
+
+def _mock_backend(start_ok: bool = True) -> MagicMock:
+    """构造 mock ZzzBackendContext:start_run 返回 (start_ok, Future)。"""
+    b = MagicMock(name='ZzzBackendContext')
+    b.start_run.return_value = (start_ok, Future())
+    b.query_status.return_value = RunStatusResult(
+        state='running',
+        source='http',
+        app='OpenAndEnterGame',
+        started_at='2026-07-02T00:00:00',
+        duration_seconds=1.0,
+    )
+    b.stop.return_value = {'stopped': True, 'source': 'http'}
+    return b
+
+
+def test_handle_game_enter_nonblock():
+    resp = asyncio.run(routes_mod.handle_game_enter(_mock_backend(), _FakeRequest({'block': 'false'})))
+    assert resp.status_code == 200
+
+
+def test_handle_game_enter_concurrent_reject():
+    resp = asyncio.run(routes_mod.handle_game_enter(_mock_backend(start_ok=False), _FakeRequest({})))
+    assert resp.status_code == 200
+    assert json.loads(resp.body)['started'] is False
+
+
+def test_handle_game_enter_block_success():
+    backend = _mock_backend()
+    fut: Future = Future()
+    fut.set_result(OperationResult(success=True))
+    backend.start_run.return_value = (True, fut)
+    resp = asyncio.run(routes_mod.handle_game_enter(backend, _FakeRequest({})))  # block 默认 true
+    assert json.loads(resp.body)['result'] == '成功打开并进入绝区零游戏'
+
+
+def test_handle_game_status():
+    resp = asyncio.run(routes_mod.handle_game_status(_mock_backend(), _FakeRequest({})))
+    assert resp.status_code == 200
+
+
+def test_handle_game_stop():
+    resp = asyncio.run(routes_mod.handle_game_stop(_mock_backend(), _FakeRequest({})))
+    assert resp.status_code == 200

--- a/test/zzz_od/backend/test_http_routes.py
+++ b/test/zzz_od/backend/test_http_routes.py
@@ -1,0 +1,223 @@
+"""HTTP ``/game/*`` 适配器的单元测试。
+
+直接 await 处理器函数，避开 MCP 协议层；backend 使用 ``MagicMock`` 伪造，
+避免依赖真实游戏窗口与 ``ZContext``。``capture`` 用例给真实 numpy 图（可编码），
+以验证 PNG 字节回传链路。
+"""
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from zzz_od.backend.backend_context import BackendNotReadyError
+from zzz_od.backend.http.routes import (
+    handle_game_analyze,
+    handle_game_capture,
+    handle_game_close,
+    handle_game_enter,
+    handle_game_window,
+)
+from zzz_od.backend.schemas import AnalyzeScreenResult, WindowStatus
+
+
+@pytest.mark.asyncio
+async def test_handle_game_window_ok() -> None:
+    """handle_game_window 在就绪时应以 200 返回窗口状态 JSON。"""
+    backend = MagicMock()
+    backend.check_window.return_value = WindowStatus(
+        win_title="绝区零", is_win_valid=True, is_win_active=False, is_win_scale=True, x=1, y=2, width=3, height=4
+    )
+    resp = await handle_game_window(backend)
+    assert resp.status_code == 200
+    data = json.loads(resp.body.decode("utf-8"))
+    assert data["win_title"] == "绝区零"
+    assert data["x"] == 1
+
+
+@pytest.mark.asyncio
+async def test_handle_game_window_error() -> None:
+    """handle_game_window 在 backend 未就绪时应返回 503。"""
+    backend = MagicMock()
+    backend.check_window.side_effect = BackendNotReadyError("未就绪")
+    resp = await handle_game_window(backend)
+    assert resp.status_code == 503
+
+
+@pytest.mark.asyncio
+async def test_handle_game_capture_returns_png_bytes() -> None:
+    """handle_game_capture 应直接回传 PNG 字节（media_type=image/png，不落盘）。"""
+    import numpy as np
+
+    backend = MagicMock()
+    backend.capture.return_value = np.zeros((1, 1, 3), dtype="uint8")  # 可编码的 1x1 RGB 图
+    resp = await handle_game_capture(backend)
+    assert resp.status_code == 200
+    assert resp.media_type == "image/png"
+    assert resp.body[:4] == b"\x89PNG"  # PNG magic
+
+
+@pytest.mark.asyncio
+async def test_handle_game_analyze_ok() -> None:
+    """handle_game_analyze 在成功时应以 200 返回分析结果 JSON。"""
+    backend = MagicMock()
+    backend.analyze.return_value = AnalyzeScreenResult(success=True, ocr_texts=[], error=None)
+    resp = await handle_game_analyze(backend)
+    assert resp.status_code == 200
+    data = json.loads(resp.body.decode("utf-8"))
+    assert data["success"] is True
+
+
+@pytest.mark.asyncio
+async def test_handle_game_analyze_returns_screens() -> None:
+    """HTTP /game/analyze 返回 JSON 含 screens 嵌套;area_type 经 asdict+json 序列化为 'text'。"""
+    from one_dragon.base.screen.screen_match import (
+        AreaMatchDetail,
+        AreaType,
+        ScreenMatch,
+    )
+
+    detail = AreaMatchDetail(
+        area_name='标题', area_type=AreaType.TEXT,
+        x=1, y=1, width=1, height=1, text='菜单', confidence=0.9,
+    )
+    match = ScreenMatch(screen_name='菜单', is_precise=True, areas=[detail])
+    backend = MagicMock()
+    backend.analyze.return_value = AnalyzeScreenResult(
+        success=True, ocr_texts=[], error=None, screens=[match])
+    resp = await handle_game_analyze(backend)  # _request 默认 None,处理器不读 request
+    assert resp.status_code == 200
+    body = json.loads(resp.body.decode('utf-8'))
+    assert body['success'] is True
+    assert body['screens'][0]['screen_name'] == '菜单'
+    # str Enum 经 asdict 保 Enum 对象、json.dumps 序列化为 'text';与 AreaType.TEXT('text') 相等
+    assert body['screens'][0]['areas'][0]['area_type'] == AreaType.TEXT
+
+
+@pytest.mark.asyncio
+async def test_handle_game_enter_ok() -> None:
+    """handle_game_enter 应委托 backend.start_run，返回 started/result JSON。
+
+    block=true（默认）且 start_run 返回 (True, 已完成 Future) 时，
+    响应体应包含 result 文本（success → 「成功打开并进入绝区零游戏」）。
+    """
+    from concurrent.futures import Future
+    from dataclasses import dataclass
+
+    from zzz_od.backend.schemas import RunStatusResult
+
+    @dataclass
+    class _FakeRequest:
+        query_params: dict
+
+        async def json(self) -> dict:
+            return {}
+
+    @dataclass
+    class _OpResult:
+        success: bool
+        status: str = ""
+
+    fut: Future = Future()
+    fut.set_result(_OpResult(success=True))
+    backend = MagicMock()
+    backend.start_run.return_value = (True, fut)
+    backend.query_status.return_value = RunStatusResult(
+        state="running", source="http", app="OpenAndEnterGame",
+        started_at="2026-07-02T00:00:00", duration_seconds=1.0,
+    )
+    resp = await handle_game_enter(backend, _FakeRequest({}))
+    assert resp.status_code == 200
+    data = json.loads(resp.body.decode("utf-8"))
+    assert data["result"] == "成功打开并进入绝区零游戏"
+    backend.start_run.assert_called_once()
+
+
+def test_register_http_routes_adds_custom_routes() -> None:
+    """register_http_routes 应在 FastMCP 上挂载 /game/* 路由。"""
+    from mcp.server.fastmcp import FastMCP
+
+    from zzz_od.backend.http.routes import register_http_routes
+
+    mcp = FastMCP("test")
+    register_http_routes(mcp, MagicMock())
+    # custom_route 挂在 Starlette 层；用 streamable_http_app 的 routes 校验
+    app = mcp.streamable_http_app()
+    paths = {getattr(r, "path", None) for r in app.routes}
+    assert any(p and "game" in p for p in paths)
+
+
+@pytest.mark.asyncio
+async def test_handle_game_close_ok() -> None:
+    """handle_game_close 在就绪时应以 200 返回 backend.close_game() 文本。"""
+    backend = MagicMock()
+    backend.close_game.return_value = "已发送关闭游戏信号,可用 check_game_window 验证"
+    resp = await handle_game_close(backend)
+    assert resp.status_code == 200
+    data = json.loads(resp.body.decode("utf-8"))
+    assert data["result"] == "已发送关闭游戏信号,可用 check_game_window 验证"
+
+
+@pytest.mark.asyncio
+async def test_handle_game_close_error() -> None:
+    """handle_game_close 在 backend 未就绪时应返回 503。"""
+    backend = MagicMock()
+    backend.close_game.side_effect = BackendNotReadyError("未就绪")
+    resp = await handle_game_close(backend)
+    assert resp.status_code == 503
+
+
+def test_route_dispatch_game_close_ok() -> None:
+    """经路由层分发 POST /game/close,应返回 200 + result 文本。"""
+    from mcp.server.fastmcp import FastMCP
+    from starlette.testclient import TestClient
+
+    from zzz_od.backend.http.routes import register_http_routes
+
+    mcp = FastMCP("test")
+    backend = MagicMock()
+    backend.close_game.return_value = "已发送关闭游戏信号,可用 check_game_window 验证"
+    register_http_routes(mcp, backend)
+    client = TestClient(mcp.streamable_http_app())
+    resp = client.post("/game/close")
+    assert resp.status_code == 200
+    assert resp.json()["result"] == "已发送关闭游戏信号,可用 check_game_window 验证"
+
+
+def test_route_dispatch_window_ok() -> None:
+    """经 Starlette 路由层分发 GET /game/window，应返回 200 + 窗口状态 JSON。
+
+    回归 ``register_http_routes`` 中同步 lambda 返回 coroutine 的 bug：
+    处理器未走真实路由分发，上面几个直调 ``handle_*`` 的用例无法覆盖。
+    """
+    from mcp.server.fastmcp import FastMCP
+    from starlette.testclient import TestClient
+
+    from zzz_od.backend.http.routes import register_http_routes
+
+    mcp = FastMCP("test")
+    backend = MagicMock()
+    backend.check_window.return_value = WindowStatus(
+        win_title="绝区零", is_win_valid=True, is_win_active=False, is_win_scale=True
+    )
+    register_http_routes(mcp, backend)
+    client = TestClient(mcp.streamable_http_app())
+    resp = client.get("/game/window")
+    assert resp.status_code == 200
+    assert resp.json()["win_title"] == "绝区零"
+
+
+def test_route_dispatch_window_not_ready() -> None:
+    """经路由层分发，backend 未就绪时应返回 503（而非 500）。"""
+    from mcp.server.fastmcp import FastMCP
+    from starlette.testclient import TestClient
+
+    from zzz_od.backend.http.routes import register_http_routes
+
+    mcp = FastMCP("test")
+    backend = MagicMock()
+    backend.check_window.side_effect = BackendNotReadyError("未就绪")
+    register_http_routes(mcp, backend)
+    client = TestClient(mcp.streamable_http_app())
+    resp = client.get("/game/window")
+    assert resp.status_code == 503

--- a/test/zzz_od/backend/test_mcp_app.py
+++ b/test/zzz_od/backend/test_mcp_app.py
@@ -1,0 +1,145 @@
+"""MCP 适配器的单元测试。
+
+测试使用 MagicMock 伪造 backend，避免依赖真实游戏窗口与 ZContext。
+通过 FastMCP 的 ``_tool_manager._tools`` 探测已注册的工具，并直接调用其
+``Tool.fn`` 验证行为（已注册 ``Tool`` 的可调用对象属性为 ``fn``）。
+"""
+
+from unittest.mock import MagicMock
+
+from mcp.server.fastmcp import FastMCP
+
+from zzz_od.backend.backend_context import BackendNotReadyError
+from zzz_od.backend.mcp.app import create_mcp_server
+from zzz_od.backend.schemas import AnalyzeScreenResult, WindowStatus
+
+
+def _mcp_with_backend() -> tuple[FastMCP, MagicMock]:
+    """构造一个 MCP 服务器与对应的伪造 backend。
+
+    Returns:
+        ``(mcp, backend)`` 元组：mcp 为注册了 6 个工具的 FastMCP 实例
+        （check/capture/analyze + open_and_enter_game/get_run_status/stop_run），
+        backend 为 MagicMock，可在测试中配置其方法返回值或副作用。
+    """
+    backend = MagicMock()
+    mcp = create_mcp_server(backend)
+    return mcp, backend
+
+
+def test_registers_all_tools() -> None:
+    """create_mcp_server 应注册 6 个 game 工具。"""
+    mcp, _ = _mcp_with_backend()
+    names = set(mcp._tool_manager._tools.keys())
+    assert {
+        "check_game_window",
+        "capture_game_screen",
+        "analyze_screen",
+        "open_and_enter_game",
+        "get_run_status",
+        "stop_run",
+    } <= names
+
+
+def test_check_game_window_tool_error_on_not_ready() -> None:
+    """check_game_window 在 backend 未就绪时返回包含「错误」的字符串。"""
+    mcp, backend = _mcp_with_backend()
+    backend.check_window.side_effect = BackendNotReadyError("未就绪")
+    tool = mcp._tool_manager._tools["check_game_window"]
+    # FastMCP 工具实际可调用对象在 .fn / .func；按版本取能 call 的那个
+    fn = getattr(tool, "fn", None) or getattr(tool, "func", None)
+    assert fn is not None
+    out = fn()
+    assert "错误" in out
+
+
+def test_analyze_tool_returns_result() -> None:
+    """analyze_screen 应直接返回 backend.analyze() 的结果。"""
+    mcp, backend = _mcp_with_backend()
+    backend.analyze.return_value = AnalyzeScreenResult(success=True, ocr_texts=[], error=None)
+    tool = mcp._tool_manager._tools["analyze_screen"]
+    fn = getattr(tool, "fn", None) or getattr(tool, "func", None)
+    result = fn()
+    assert result.success is True
+
+
+def test_analyze_screen_tool_returns_screens_field() -> None:
+    """analyze_screen tool 直接调用应返回带 screens 的 AnalyzeScreenResult(验证嵌套结构)。
+
+    MCP 经 FastMCP/pydantic 的 JSON 序列化由框架保证(与 HTTP 同源 dataclass);
+    端到端 JSON 序列化(area_type → 'text')由 HTTP 测试覆盖。此处验证 tool.fn
+    返回的 dataclass 结构正确。
+    """
+    from one_dragon.base.screen.screen_match import (
+        AreaMatchDetail,
+        AreaType,
+        ScreenMatch,
+    )
+
+    mcp, backend = _mcp_with_backend()
+    detail = AreaMatchDetail(
+        area_name='标题', area_type=AreaType.TEXT,
+        x=1, y=1, width=1, height=1, text='菜单',
+    )
+    match = ScreenMatch(screen_name='菜单', is_precise=True, areas=[detail])
+    backend.analyze.return_value = AnalyzeScreenResult(
+        success=True, ocr_texts=[], error=None, screens=[match])
+    tool = mcp._tool_manager._tools['analyze_screen']
+    fn = getattr(tool, 'fn', None) or getattr(tool, 'func', None)
+    result = fn()
+    assert result.success is True
+    assert result.screens[0].screen_name == '菜单'
+    assert result.screens[0].areas[0].area_type == AreaType.TEXT
+
+
+def test_check_game_window_formats_status() -> None:
+    """check_game_window 在就绪时应格式化输出窗口状态字段。"""
+    mcp, backend = _mcp_with_backend()
+    backend.check_window.return_value = WindowStatus(
+        win_title="ZenlessZoneZero",
+        is_win_valid=True,
+        is_win_active=False,
+        is_win_scale=True,
+        x=10,
+        y=20,
+        width=1920,
+        height=1080,
+    )
+    tool = mcp._tool_manager._tools["check_game_window"]
+    fn = getattr(tool, "fn", None) or getattr(tool, "func", None)
+    out = fn()
+    assert "ZenlessZoneZero" in out
+    assert "x=10" in out
+
+
+def test_close_game_tool_registered() -> None:
+    """create_mcp_server 应注册内联 close_game tool(同 check_game_window,非工厂)。"""
+    import asyncio
+
+    mcp, _ = _mcp_with_backend()
+    tools = asyncio.run(mcp.list_tools())
+    assert any(t.name == "close_game" for t in tools)
+
+
+def test_close_game_tool_error_on_not_ready() -> None:
+    """close_game 在 backend 未就绪时返回包含「错误」的字符串(工具层兜底)。"""
+    mcp, backend = _mcp_with_backend()
+    backend.close_game.side_effect = BackendNotReadyError("未就绪")
+    tool = mcp._tool_manager._tools["close_game"]
+    fn = getattr(tool, "fn", None) or getattr(tool, "func", None)
+    assert fn is not None
+    out = fn()
+    assert "错误" in out
+
+
+def test_capture_game_screen_returns_path() -> None:
+    """capture_game_screen 应保存截图并返回保存路径字符串。"""
+    import numpy as np
+
+    mcp, backend = _mcp_with_backend()
+    backend.capture.return_value = np.zeros((4, 4, 3), dtype=np.uint8)
+    tool = mcp._tool_manager._tools["capture_game_screen"]
+    fn = getattr(tool, "fn", None) or getattr(tool, "func", None)
+    path = fn()
+    assert isinstance(path, str)
+    assert path.endswith(".png")

--- a/test/zzz_od/backend/test_mcp_app.py
+++ b/test/zzz_od/backend/test_mcp_app.py
@@ -1,0 +1,71 @@
+"""MCP app 模块级 tool 工厂的单元测试(mock backend)。"""
+
+import asyncio
+from concurrent.futures import Future
+from unittest.mock import MagicMock
+
+from one_dragon.base.operation.operation_base import OperationResult
+from zzz_od.backend.mcp import app as app_mod
+from zzz_od.backend.schemas import RunStatusResult
+
+
+def _mock_backend(start_ok: bool = True) -> MagicMock:
+    """构造一个 mock ZzzBackendContext,start_run 返回 (start_ok, Future)。"""
+    b = MagicMock(name='ZzzBackendContext')
+    b.start_run.return_value = (start_ok, Future())
+    b.query_status.return_value = RunStatusResult(
+        state='running',
+        source='mcp',
+        app='OpenAndEnterGame',
+        started_at='2026-07-02T00:00:00',
+        duration_seconds=1.0,
+    )
+    b.stop.return_value = {'stopped': False, 'error': '当前无运行'}
+    return b
+
+
+def test_open_and_enter_game_nonblock_returns_started() -> None:
+    backend = _mock_backend()
+    tool = app_mod.make_open_and_enter_game(backend)
+    res = asyncio.run(tool(block=False))
+    assert res['started'] is True
+    backend.start_run.assert_called_once()
+
+
+def test_open_and_enter_game_concurrent_reject() -> None:
+    backend = _mock_backend(start_ok=False)
+    tool = app_mod.make_open_and_enter_game(backend)
+    res = asyncio.run(tool(block=False))
+    assert res['started'] is False and 'source' in res
+
+
+def test_open_and_enter_game_block_success() -> None:
+    backend = _mock_backend()
+    fut: Future = Future()
+    fut.set_result(OperationResult(success=True, status='成功'))
+    backend.start_run.return_value = (True, fut)
+    tool = app_mod.make_open_and_enter_game(backend)
+    assert asyncio.run(tool(block=True)) == '成功打开并进入绝区零游戏'
+
+
+def test_open_and_enter_game_block_failed() -> None:
+    backend = _mock_backend()
+    fut: Future = Future()
+    fut.set_result(OperationResult(success=False, status='打开游戏失败'))
+    backend.start_run.return_value = (True, fut)
+    tool = app_mod.make_open_and_enter_game(backend)
+    assert asyncio.run(tool(block=True)) == '打开游戏失败: 打开游戏失败'
+
+
+def test_get_run_status_delegates() -> None:
+    backend = _mock_backend()
+    res = app_mod.make_get_run_status(backend)()
+    assert isinstance(res, RunStatusResult)
+    backend.query_status.assert_called_once()
+
+
+def test_stop_run_delegates() -> None:
+    backend = _mock_backend()
+    res = app_mod.make_stop_run(backend)()
+    assert res['stopped'] is False
+    backend.stop.assert_called_once()

--- a/test/zzz_od/backend/test_mcp_app.py
+++ b/test/zzz_od/backend/test_mcp_app.py
@@ -69,3 +69,10 @@ def test_stop_run_delegates() -> None:
     res = app_mod.make_stop_run(backend)()
     assert res['stopped'] is False
     backend.stop.assert_called_once()
+
+
+def test_close_game_tool_registered() -> None:
+    """close_game tool 用内联 @mcp.tool() 注册(同 check_game_window),用 list_tools 验名字。"""
+    mcp = app_mod.create_mcp_server(MagicMock(name='ZzzBackendContext'))
+    tools = asyncio.run(mcp.list_tools())
+    assert any(t.name == 'close_game' for t in tools)

--- a/test/zzz_od/backend/test_run_slot.py
+++ b/test/zzz_od/backend/test_run_slot.py
@@ -130,3 +130,20 @@ def test_query_status_terminal_failed(slot):
     assert r.failed_node == '进入游戏'
     assert r.app == 'OpenAndEnterGame'
     assert r.current_node is None
+
+
+def test_stop_idle_returns_false(slot):
+    """无运行时 _stop 返回 (False, None),不调 stop_running。"""
+    assert slot._stop() == (False, None)
+
+
+def test_stop_running_signals_stop(slot, mock_ctx):
+    """运行中 _stop 读出 source、锁外调 stop_running,返回 (True, source)。"""
+    event = threading.Event()
+    slot._start_run('http', _make_blocking_op(event, OperationResult(success=True)))
+    try:
+        stopped, source = slot._stop()
+        assert stopped is True and source == 'http'
+        assert mock_ctx.run_context.stop_running.called
+    finally:
+        event.set()

--- a/test/zzz_od/backend/test_run_slot.py
+++ b/test/zzz_od/backend/test_run_slot.py
@@ -85,9 +85,10 @@ def test_run_init_failed(slot, mock_ctx):
 
 def test_run_exception(slot):
     _, fut = slot._start_run('mcp', _make_op(raises=RuntimeError('boom')))
-    fut.result(timeout=5)
+    result = fut.result(timeout=5)
     assert slot.terminal_state == RunState.FAILED
     assert slot.last_status == '执行异常'
+    assert result is not None and result.success is False   # future 解析值非 None,适配器 block=True 取 .success 不崩
 
 
 def test_run_syncs_current_instance_idx(slot, mock_ctx):

--- a/test/zzz_od/backend/test_run_slot.py
+++ b/test/zzz_od/backend/test_run_slot.py
@@ -1,8 +1,10 @@
 import threading
+import time
 from unittest.mock import MagicMock
 
 from one_dragon.base.operation.operation_base import OperationResult
 from zzz_od.backend.backend_context import RunState
+from zzz_od.backend.schemas import RunStatusResult
 
 
 def _make_op(result=None, raises=None, node_cn='进入游戏'):
@@ -93,3 +95,38 @@ def test_run_syncs_current_instance_idx(slot, mock_ctx):
     _, fut = slot._start_run('mcp', _make_op(OperationResult(success=True)))
     fut.result(timeout=5)
     assert mock_ctx.run_context.current_instance_idx == 7
+
+
+def test_query_status_idle(slot):
+    r = slot._query_status()
+    assert isinstance(r, RunStatusResult)
+    assert r.state == 'idle' and r.source is None
+
+
+def test_query_status_running(slot):
+    event = threading.Event()
+    slot._start_run('mcp', _make_blocking_op(event, OperationResult(success=True)))
+    try:
+        # 等后台线程进入 blocking op(设置了 current_op 后才阻塞在 event.wait)。
+        deadline = time.time() + 5
+        while slot.current_op is None and time.time() < deadline:
+            time.sleep(0.01)
+        r = slot._query_status()
+        assert r.state == 'running'
+        assert r.source == 'mcp'
+        assert r.current_node == '等待游戏打开'
+        assert r.retry_count == 0
+        assert r.started_at is not None and r.duration_seconds is not None
+    finally:
+        event.set()
+
+
+def test_query_status_terminal_failed(slot):
+    _, fut = slot._start_run('mcp', _make_op(OperationResult(success=False, status='打开游戏失败')))
+    fut.result(timeout=5)
+    r = slot._query_status()
+    assert r.state == 'failed'
+    assert r.last_status == '打开游戏失败'
+    assert r.failed_node == '进入游戏'
+    assert r.app == 'OpenAndEnterGame'
+    assert r.current_node is None

--- a/test/zzz_od/backend/test_run_slot.py
+++ b/test/zzz_od/backend/test_run_slot.py
@@ -1,0 +1,95 @@
+import threading
+from unittest.mock import MagicMock
+
+from one_dragon.base.operation.operation_base import OperationResult
+from zzz_od.backend.backend_context import RunState
+
+
+def _make_op(result=None, raises=None, node_cn='进入游戏'):
+    """构造 mock op factory;execute 阻塞到 event(若传)或立即返回 result/抛 raises。"""
+    def factory(ctx):
+        op = MagicMock(name='Operation')
+        op.__class__ = type('OpenAndEnterGame', (), {})  # 让 __class__.__name__ == 'OpenAndEnterGame'
+        node = MagicMock()
+        node.cn = node_cn
+        op._current_node = node
+        op.node_retry_times = 2
+        if raises is not None:
+            op.execute.side_effect = raises
+        else:
+            op.execute.return_value = result
+        return op
+    return factory
+
+
+def _make_blocking_op(event, result):
+    """execute 阻塞到 event.set() 的 factory(用于并发拒绝 / running 查询测试)。"""
+    def factory(ctx):
+        op = MagicMock(name='Operation')
+        op.__class__ = type('OpenAndEnterGame', (), {})
+        node = MagicMock()
+        node.cn = '等待游戏打开'
+        op._current_node = node
+        op.node_retry_times = 0
+        def _execute():
+            event.wait(timeout=10)
+            return result
+        op.execute.side_effect = _execute
+        return op
+    return factory
+
+
+def test_start_run_rejects_when_running(slot):
+    """单跑道:第一个运行阻塞中时,第二次 _start_run 必须被拒。"""
+    event = threading.Event()
+    slot._start_run('mcp', _make_blocking_op(event, OperationResult(success=True)))
+    try:
+        ok, fut = slot._start_run('http', _make_blocking_op(event, OperationResult(success=True)))
+        assert ok is False and fut is None
+    finally:
+        event.set()  # 释放后台线程
+
+
+def test_run_success(slot):
+    _, fut = slot._start_run('mcp', _make_op(OperationResult(success=True, status='成功打开并进入游戏')))
+    fut.result(timeout=5)
+    assert slot.terminal_state == RunState.SUCCESS
+    assert slot.last_status == '成功打开并进入游戏'
+    assert slot.app == 'OpenAndEnterGame'
+    assert slot.finished_at is not None
+
+
+def test_run_failed(slot):
+    _, fut = slot._start_run('mcp', _make_op(OperationResult(success=False, status='打开游戏失败')))
+    fut.result(timeout=5)
+    assert slot.terminal_state == RunState.FAILED
+    assert slot.failed_node == '进入游戏'
+    assert slot.last_status == '打开游戏失败'
+
+
+def test_run_stopped(slot):
+    _, fut = slot._start_run('mcp', _make_op(OperationResult(success=False, status='人工结束')))
+    fut.result(timeout=5)
+    assert slot.terminal_state == RunState.STOPPED
+
+
+def test_run_init_failed(slot, mock_ctx):
+    mock_ctx.run_context.start_running.return_value = False
+    _, fut = slot._start_run('mcp', _make_op(OperationResult(success=True)))
+    fut.result(timeout=5)
+    assert slot.terminal_state == RunState.FAILED
+    assert slot.failed_node == 'start_running 初始化失败'
+
+
+def test_run_exception(slot):
+    _, fut = slot._start_run('mcp', _make_op(raises=RuntimeError('boom')))
+    fut.result(timeout=5)
+    assert slot.terminal_state == RunState.FAILED
+    assert slot.last_status == '执行异常'
+
+
+def test_run_syncs_current_instance_idx(slot, mock_ctx):
+    mock_ctx.current_instance_idx = 7
+    _, fut = slot._start_run('mcp', _make_op(OperationResult(success=True)))
+    fut.result(timeout=5)
+    assert mock_ctx.run_context.current_instance_idx == 7

--- a/test/zzz_od/backend/test_run_slot.py
+++ b/test/zzz_od/backend/test_run_slot.py
@@ -147,3 +147,33 @@ def test_stop_running_signals_stop(slot, mock_ctx):
         assert mock_ctx.run_context.stop_running.called
     finally:
         event.set()
+
+
+def test_context_start_run_delegates(slot, mock_ctx):
+    """ZzzBackendContext.start_run 转发 run_slot._start_run,返回 (ok, future)。"""
+    from zzz_od.backend.backend_context import ZzzBackendContext
+
+    backend = ZzzBackendContext(mock_ctx)
+    backend.run_slot = slot
+    event = threading.Event(); event.set()
+    ok, fut = backend.start_run('mcp', _make_op(OperationResult(success=True)))
+    assert ok is True and fut is not None
+    fut.result(timeout=5)
+
+
+def test_context_query_status_delegates(slot, mock_ctx):
+    """ZzzBackendContext.query_status 转发 run_slot._query_status。"""
+    from zzz_od.backend.backend_context import ZzzBackendContext
+
+    backend = ZzzBackendContext(mock_ctx)
+    backend.run_slot = slot
+    assert backend.query_status().state == 'idle'
+
+
+def test_context_stop_delegates(slot, mock_ctx):
+    """ZzzBackendContext.stop 封装 run_slot._stop,无运行时返 {stopped:False, error}。"""
+    from zzz_od.backend.backend_context import ZzzBackendContext
+
+    backend = ZzzBackendContext(mock_ctx)
+    backend.run_slot = slot
+    assert backend.stop() == {'stopped': False, 'error': '当前无运行'}

--- a/test/zzz_od/backend/test_schemas.py
+++ b/test/zzz_od/backend/test_schemas.py
@@ -50,7 +50,7 @@ def test_analyze_result_asdict_nested_serializable() -> None:
     match = ScreenMatch(screen_name='菜单', is_precise=True, areas=[detail])
     r = AnalyzeScreenResult(success=True, ocr_texts=[], screens=[match], error=None)
     d = asdict(r)
-    assert d['screens'][0]['areas'][0]['area_type'] == AreaType.TEXT  # str Enum 原值
+    assert d['screens'][0]['areas'][0]['area_type'] == 'text'  # str Enum 序列化为 .value 字符串(asdict 后保留 Enum 实例, == 'text' 验证 str 值非枚举自比)
 
 
 def test_run_status_result_fields() -> None:

--- a/test/zzz_od/backend/test_schemas.py
+++ b/test/zzz_od/backend/test_schemas.py
@@ -1,0 +1,48 @@
+from dataclasses import asdict
+
+from one_dragon.base.screen.screen_match import AreaMatchDetail, AreaType, ScreenMatch
+from zzz_od.backend.schemas import AnalyzeScreenResult, OcrText, WindowStatus
+
+
+def test_ocr_text_fields() -> None:
+    """校验 OcrText 各字段的取值与默认值。"""
+    t = OcrText(text="体力", x=10, y=20, width=30, height=40)
+    assert t.text == "体力"
+    assert (t.x, t.y, t.width, t.height) == (10, 20, 30, 40)
+
+
+def test_analyze_result_default_error_none() -> None:
+    """校验 AnalyzeScreenResult 的 error 默认为 None、ocr_texts 透传。"""
+    r = AnalyzeScreenResult(success=True, ocr_texts=[])
+    assert r.error is None
+    assert r.ocr_texts == []
+
+
+def test_window_status_optional_rect() -> None:
+    """校验 WindowStatus 的窗口矩形字段可选，缺省为 None。"""
+    w = WindowStatus(win_title="绝区零", is_win_valid=True, is_win_active=True, is_win_scale=True)
+    assert w.x is None
+    assert w.width is None
+    w2 = WindowStatus(win_title="t", is_win_valid=True, is_win_active=False, is_win_scale=True, x=1, y=2, width=3, height=4)
+    assert (w2.x, w2.y, w2.width, w2.height) == (1, 2, 3, 4)
+
+
+def test_analyze_result_has_screens_field() -> None:
+    """AnalyzeScreenResult 含 screens 字段,可装 ScreenMatch 列表。"""
+    detail = AreaMatchDetail(area_name='标题', area_type=AreaType.TEXT,
+                             x=1, y=1, width=1, height=1, text='菜单')
+    match = ScreenMatch(screen_name='菜单', is_precise=True, areas=[detail])
+    r = AnalyzeScreenResult(success=True, ocr_texts=[], screens=[match], error=None)
+    assert r.success is True
+    assert len(r.screens) == 1
+    assert r.screens[0].screen_name == '菜单'
+
+
+def test_analyze_result_asdict_nested_serializable() -> None:
+    """asdict 递归嵌套 dataclass + str Enum,可序列化(area_type 序列化为 'text')。"""
+    detail = AreaMatchDetail(area_name='标题', area_type=AreaType.TEXT,
+                             x=1, y=1, width=1, height=1, text='菜单')
+    match = ScreenMatch(screen_name='菜单', is_precise=True, areas=[detail])
+    r = AnalyzeScreenResult(success=True, ocr_texts=[], screens=[match], error=None)
+    d = asdict(r)
+    assert d['screens'][0]['areas'][0]['area_type'] == AreaType.TEXT  # str Enum 原值

--- a/test/zzz_od/backend/test_schemas.py
+++ b/test/zzz_od/backend/test_schemas.py
@@ -1,0 +1,17 @@
+from dataclasses import fields
+
+from zzz_od.backend.schemas import RunStatusResult
+
+
+def test_run_status_result_fields():
+    names = {f.name for f in fields(RunStatusResult)}
+    assert names == {
+        'state', 'source', 'app', 'started_at', 'duration_seconds',
+        'current_node', 'retry_count', 'last_status', 'failed_node',
+    }
+
+
+def test_run_status_result_defaults():
+    r = RunStatusResult(state='idle')
+    assert r.source is None and r.app is None
+    assert r.current_node is None and r.last_status is None and r.failed_node is None


### PR DESCRIPTION
## 背景
配合主仓 PR(ZenlessZoneZero-OneDragon `unify-test-tree`)归一测试树:主仓 `tests/` 11 测试搬到本仓 `test/` + 合并本地 `backend/run-status-schema` 分支的 backend 用例。

## 改动

### 归一(@78b17f9 + @ccb85d8)
- 搬 11 测试到 `test/`(`ocr_utilss`->`ocr_utils` 纠正、gpu 去 `sys.path`)
- 修 7 预存失败(git_service/code_sync API 漂移)

### 合并 backend/run-status-schema(@d76fd0c merge)
- 合并 RunSlot/close_game/http/mcp/schemas backend 用例
- 3 同名文件(test_http_routes/test_mcp_app/test_schemas)合并两边用例、去重

## 验证
- `pytest zzz-od-test/test/zzz_od/backend/` 72 passed

## 主仓 PR
ZenlessZoneZero-OneDragon `unify-test-tree`(fork-aware CI 拉本分支)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * 新增多组单元测试，覆盖 OCR 匹配、屏幕识别、GPU 推理并发、代码同步进度、CV 超时控制，以及后端上下文、HTTP/MCP 路由和运行状态相关流程。
  * 补充了测试夹具与模拟对象，提升了对成功、失败、超时、并发和缓存场景的验证覆盖。
  * 强化了关键结果返回、进度输出、异常处理与序列化行为的回归保障。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->