### PR TITLE
test: interactive-game-ops(click_game/input_text/open_game 单测)

### DIFF
--- a/test/zzz_od/backend/test_backend_context.py
+++ b/test/zzz_od/backend/test_backend_context.py
@@ -312,3 +312,23 @@ def test_analyze_save_image_capture_fails_no_path() -> None:
     result = backend.analyze(save_image=True)
     assert result.success is False
     assert result.screenshot_path is None
+
+
+def test_analyze_save_image_then_ocr_fail_returns_path(monkeypatch) -> None:
+    """存盘成功但后续 OCR 异常 → success=False, screenshot_path 仍回传(排障)。"""
+    import numpy as np
+    import zzz_od.backend.backend_context as bc
+
+    monkeypatch.setattr(bc, '_save_screenshot', lambda img: '/tmp/fake.png')
+    controller = MagicMock()
+    controller.is_game_window_ready = True
+    controller.get_screenshot.return_value = np.zeros((4, 4, 3), dtype=np.uint8)
+    ctx = MagicMock()
+    ctx.ready_for_application = True
+    ctx.controller = controller
+    ctx.ocr_service.get_ocr_result_list.side_effect = RuntimeError('ocr boom')
+    backend = ZzzBackendContext(ctx)
+    result = backend.analyze(save_image=True)
+    assert result.success is False
+    assert result.screenshot_path == '/tmp/fake.png'
+    assert result.error is not None

--- a/test/zzz_od/backend/test_backend_context.py
+++ b/test/zzz_od/backend/test_backend_context.py
@@ -235,3 +235,80 @@ def test_close_game_delegates() -> None:
     msg = backend.close_game()
     controller.close_game.assert_called_once()
     assert msg == '已发送关闭游戏信号,可用 check_game_window 验证'
+
+
+def test_analyze_save_image_persists_and_returns_path(monkeypatch) -> None:
+    """analyze(save_image=True) 实时模式:存盘 + screenshot_path 回传路径。"""
+    import numpy as np
+    import zzz_od.backend.backend_context as bc
+
+    saved_args: list = []
+
+    def fake_save(image):
+        saved_args.append(image)
+        return '/tmp/fake_screenshot.png'
+
+    monkeypatch.setattr(bc, '_save_screenshot', fake_save)
+    controller = MagicMock()
+    controller.is_game_window_ready = True
+    controller.get_screenshot.return_value = np.zeros((4, 4, 3), dtype=np.uint8)
+    ctx = MagicMock()
+    ctx.ready_for_application = True
+    ctx.controller = controller
+    ctx.ocr_service.get_ocr_result_list.return_value = []
+    backend = ZzzBackendContext(ctx)
+    result = backend.analyze(save_image=True)
+    assert result.success is True
+    assert result.screenshot_path == '/tmp/fake_screenshot.png'
+    assert len(saved_args) == 1
+
+
+def test_analyze_save_image_false_does_not_persist(monkeypatch) -> None:
+    """analyze() 默认 save_image=False:不存盘,screenshot_path=None。"""
+    import zzz_od.backend.backend_context as bc
+
+    called: list = []
+    monkeypatch.setattr(bc, '_save_screenshot', lambda img: called.append(img) or '/tmp/x.png')
+    controller = MagicMock()
+    controller.is_game_window_ready = True
+    controller.get_screenshot.return_value = object()
+    ctx = MagicMock()
+    ctx.ready_for_application = True
+    ctx.controller = controller
+    ctx.ocr_service.get_ocr_result_list.return_value = []
+    backend = ZzzBackendContext(ctx)
+    result = backend.analyze()
+    assert result.success is True
+    assert result.screenshot_path is None
+    assert called == []
+
+
+def test_analyze_offline_ignores_save_image(monkeypatch, tmp_path) -> None:
+    """analyze(screenshot=path) 离线模式:save_image 被忽略,screenshot_path=None。"""
+    import cv2
+    import numpy as np
+    import zzz_od.backend.backend_context as bc
+
+    called: list = []
+    monkeypatch.setattr(bc, '_save_screenshot', lambda img: called.append(img) or '/tmp/x.png')
+    img_path = tmp_path / 'shot.png'
+    cv2.imwrite(str(img_path), np.zeros((4, 4, 3), dtype=np.uint8))
+    ctx = MagicMock()
+    ctx.ready_for_application = True
+    ctx.ocr_service.get_ocr_result_list.return_value = []
+    backend = ZzzBackendContext(ctx)
+    result = backend.analyze(screenshot=str(img_path), save_image=True)
+    assert result.success is True
+    assert result.screenshot_path is None
+    assert called == []
+
+
+def test_analyze_save_image_capture_fails_no_path() -> None:
+    """实时捕获失败(get_screenshot None)→ success=False,screenshot_path=None。"""
+    controller = MagicMock()
+    controller.is_game_window_ready = True
+    controller.get_screenshot.return_value = None
+    backend = _backend(ready=True, controller=controller)
+    result = backend.analyze(save_image=True)
+    assert result.success is False
+    assert result.screenshot_path is None

--- a/test/zzz_od/backend/test_click_game.py
+++ b/test/zzz_od/backend/test_click_game.py
@@ -1,0 +1,52 @@
+"""ZzzBackendContext.click_game() 的单元测试(独立仓)。"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from zzz_od.backend.backend_context import BackendNotReadyError, ZzzBackendContext
+
+
+@pytest.fixture
+def mock_ctx_game_ready():
+    """游戏就绪的 mock ZContext。"""
+    ctx = MagicMock(name='ZContext')
+    ctx.ready_for_application = True
+    ctx.controller.is_game_window_ready = True
+    ctx.controller.click.return_value = True
+    return ctx
+
+
+def test_click_game_delegates_to_controller(mock_ctx_game_ready):
+    """click_game 应激活窗口并委托 controller.click(Point(x,y), press_time=...)。"""
+    backend = ZzzBackendContext(mock_ctx_game_ready)
+    result = backend.click_game(960, 540, press_time=0.5)
+    mock_ctx_game_ready.controller.active_window.assert_called_once()
+    call = mock_ctx_game_ready.controller.click.call_args
+    # Point 无 __eq__(比 id),故比坐标字段而非 == Point(...)
+    assert (call.args[0].x, call.args[0].y) == (960, 540)
+    assert call.kwargs['press_time'] == 0.5
+    assert result == {'success': True, 'x': 960, 'y': 540, 'in_window': True}
+
+
+def test_click_game_out_of_window_returns_false(mock_ctx_game_ready):
+    """controller.click 返 False(坐标不在窗口内)时 success/in_window=False。"""
+    mock_ctx_game_ready.controller.click.return_value = False
+    backend = ZzzBackendContext(mock_ctx_game_ready)
+    result = backend.click_game(9999, 9999)
+    assert result == {'success': False, 'x': 9999, 'y': 9999, 'in_window': False}
+
+
+def test_click_game_window_not_ready_raises(mock_ctx_game_ready):
+    """游戏窗口未就绪时 click_game 抛 BackendNotReadyError。"""
+    mock_ctx_game_ready.controller.is_game_window_ready = False
+    backend = ZzzBackendContext(mock_ctx_game_ready)
+    with pytest.raises(BackendNotReadyError):
+        backend.click_game(100, 100)
+
+
+def test_click_game_default_press_time_zero(mock_ctx_game_ready):
+    """press_time 默认 0。"""
+    backend = ZzzBackendContext(mock_ctx_game_ready)
+    backend.click_game(10, 20)
+    assert mock_ctx_game_ready.controller.click.call_args.kwargs['press_time'] == 0.0

--- a/test/zzz_od/backend/test_http_routes.py
+++ b/test/zzz_od/backend/test_http_routes.py
@@ -129,6 +129,31 @@ async def test_handle_game_analyze_returns_screens() -> None:
 
 
 @pytest.mark.asyncio
+async def test_handle_game_analyze_save_image_param() -> None:
+    """handle_game_analyze 从 query 读 save_image 并透传,响应含 screenshot_path。"""
+    backend = MagicMock()
+    backend.analyze.return_value = AnalyzeScreenResult(
+        success=True, ocr_texts=[], error=None, screenshot_path='/tmp/x.png')
+    request = MagicMock()
+    request.query_params = {'save_image': 'true'}
+    resp = await handle_game_analyze(backend, request)
+    assert resp.status_code == 200
+    data = json.loads(resp.body.decode('utf-8'))
+    assert data['screenshot_path'] == '/tmp/x.png'
+    backend.analyze.assert_called_once_with(None, True)
+
+
+@pytest.mark.asyncio
+async def test_handle_game_analyze_save_image_default_false() -> None:
+    """无 request 时 save_image 默认 False(向后兼容旧调用)。"""
+    backend = MagicMock()
+    backend.analyze.return_value = AnalyzeScreenResult(success=True, ocr_texts=[], error=None)
+    resp = await handle_game_analyze(backend)  # request 默认 None
+    assert resp.status_code == 200
+    backend.analyze.assert_called_once_with(None, False)
+
+
+@pytest.mark.asyncio
 async def test_handle_game_enter_ok() -> None:
     """handle_game_enter 应委托 backend.start_run，返回 started/result JSON。
 

--- a/test/zzz_od/backend/test_input_text.py
+++ b/test/zzz_od/backend/test_input_text.py
@@ -1,0 +1,75 @@
+"""ZzzBackendContext.input_text() 的单元测试(独立仓)。"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from one_dragon.base.config.basic_game_config import TypeInputWay
+from zzz_od.backend.backend_context import BackendNotReadyError, ZzzBackendContext
+
+
+@pytest.fixture
+def mock_ctx_game_ready():
+    """游戏就绪的 mock ZContext;默认 type_input_way=剪贴板。"""
+    ctx = MagicMock(name='ZContext')
+    ctx.ready_for_application = True
+    ctx.controller.is_game_window_ready = True
+    ctx.game_config.type_input_way = TypeInputWay.CLIPBOARD.value.value  # 'clipboard'
+    return ctx
+
+
+@patch('zzz_od.backend.backend_context.PcClipboard')
+def test_input_text_clipboard_by_override(mock_pc_clipboard, mock_ctx_game_ready):
+    """use_clipboard=True 强制走剪贴板。"""
+    backend = ZzzBackendContext(mock_ctx_game_ready)
+    result = backend.input_text('13800001234', use_clipboard=True)
+    mock_ctx_game_ready.controller.active_window.assert_called_once()
+    mock_pc_clipboard.copy_and_paste.assert_called_once_with('13800001234')
+    mock_ctx_game_ready.controller.input_str.assert_not_called()
+    assert result['success'] is True
+    assert result['method'] == 'clipboard'
+
+
+@patch('zzz_od.backend.backend_context.PcClipboard')
+def test_input_text_keyboard_by_override(mock_pc_clipboard, mock_ctx_game_ready):
+    """use_clipboard=False 强制走逐键(controller.input_str)。"""
+    backend = ZzzBackendContext(mock_ctx_game_ready)
+    result = backend.input_text('abc', use_clipboard=False)
+    mock_ctx_game_ready.controller.input_str.assert_called_once_with('abc')
+    mock_pc_clipboard.copy_and_paste.assert_not_called()
+    assert result['method'] == 'keyboard'
+
+
+@patch('zzz_od.backend.backend_context.PcClipboard')
+def test_input_text_none_follows_config_clipboard(mock_pc_clipboard, mock_ctx_game_ready):
+    """use_clipboard=None + 配置=clipboard → 走剪贴板。"""
+    backend = ZzzBackendContext(mock_ctx_game_ready)
+    backend.input_text('x', use_clipboard=None)
+    mock_pc_clipboard.copy_and_paste.assert_called_once_with('x')
+
+
+@patch('zzz_od.backend.backend_context.PcClipboard')
+def test_input_text_none_follows_config_keyboard(mock_pc_clipboard, mock_ctx_game_ready):
+    """use_clipboard=None + 配置≠clipboard → 走逐键。"""
+    mock_ctx_game_ready.game_config.type_input_way = 'keyboard'
+    backend = ZzzBackendContext(mock_ctx_game_ready)
+    backend.input_text('x', use_clipboard=None)
+    mock_ctx_game_ready.controller.input_str.assert_called_once_with('x')
+    mock_pc_clipboard.copy_and_paste.assert_not_called()
+
+
+@patch('zzz_od.backend.backend_context.PcClipboard')
+def test_input_text_masks_sensitive_text(mock_pc_clipboard, mock_ctx_game_ready):
+    """返回的 masked_text 应为脱敏文本(非明文)。"""
+    backend = ZzzBackendContext(mock_ctx_game_ready)
+    result = backend.input_text('13800001234', use_clipboard=True)
+    assert result['masked_text'] != '13800001234'
+    assert isinstance(result['masked_text'], str)
+
+
+def test_input_text_window_not_ready_raises(mock_ctx_game_ready):
+    """游戏窗口未就绪时 input_text 抛 BackendNotReadyError。"""
+    mock_ctx_game_ready.controller.is_game_window_ready = False
+    backend = ZzzBackendContext(mock_ctx_game_ready)
+    with pytest.raises(BackendNotReadyError):
+        backend.input_text('x')

--- a/test/zzz_od/backend/test_mcp_app.py
+++ b/test/zzz_od/backend/test_mcp_app.py
@@ -5,7 +5,7 @@
 包含两类用例（互补）：
 - ``_mcp_with_backend`` + 直接 await/调用 ``Tool.fn``：覆盖 check/capture/analyze
   + close_game 工具的注册与行为（来自 understand-game 主仓归一）。
-- ``_mock_backend`` + ``app_mod.make_*`` 工厂：覆盖 open_and_enter_game/get_run_status
+- ``_mock_backend`` + ``app_mod.make_*`` 工厂：覆盖 open_game/get_run_status
   /stop_run 的委托与 block/nonblock/失败分支（来自 backend/run-status-schema）。
 """
 
@@ -24,8 +24,9 @@ def _mcp_with_backend() -> tuple[object, MagicMock]:
     """构造一个 MCP 服务器与对应的伪造 backend。
 
     Returns:
-        ``(mcp, backend)`` 元组：mcp 为注册了 6 个工具的 FastMCP 实例
-        （check/capture/analyze + open_and_enter_game/get_run_status/stop_run），
+        ``(mcp, backend)`` 元组：mcp 为注册了全部 game 工具的 FastMCP 实例
+        （check/capture/analyze + close_game/click_game/input_text
+        + open_game/get_run_status/stop_run），
         backend 为 MagicMock，可在测试中配置其方法返回值或副作用。
     """
     backend = MagicMock()
@@ -51,14 +52,16 @@ def _mock_backend(start_ok: bool = True) -> MagicMock:
 # ===== check/capture/analyze/close_game 工具注册与行为 =====
 
 def test_registers_all_tools() -> None:
-    """create_mcp_server 应注册 6 个 game 工具。"""
+    """create_mcp_server 应注册全部 game 工具(open_game 替换 open_and_enter_game + 新增 click/input)。"""
     mcp, _ = _mcp_with_backend()
     names = set(mcp._tool_manager._tools.keys())
     assert {
         "check_game_window",
         "capture_game_screen",
         "analyze_screen",
-        "open_and_enter_game",
+        "open_game",
+        "click_game",
+        "input_text",
         "get_run_status",
         "stop_run",
     } <= names
@@ -166,39 +169,75 @@ def test_capture_game_screen_returns_path() -> None:
     assert path.endswith(".png")
 
 
-# ===== open_and_enter_game/get_run_status/stop_run 工厂委托 =====
+# ===== open_game 工厂委托(enter 选 op)+ get_run_status/stop_run =====
 
-def test_open_and_enter_game_nonblock_returns_started() -> None:
+def test_open_game_nonblock_returns_started() -> None:
     backend = _mock_backend()
-    tool = app_mod.make_open_and_enter_game(backend)
-    res = asyncio.run(tool(block=False))
+    tool = app_mod.make_open_game(backend)
+    res = asyncio.run(tool(enter=True, block=False))
     assert res['started'] is True
     backend.start_run.assert_called_once()
 
 
-def test_open_and_enter_game_concurrent_reject() -> None:
+def test_open_game_concurrent_reject() -> None:
     backend = _mock_backend(start_ok=False)
-    tool = app_mod.make_open_and_enter_game(backend)
-    res = asyncio.run(tool(block=False))
+    tool = app_mod.make_open_game(backend)
+    res = asyncio.run(tool(enter=True, block=False))
     assert res['started'] is False and 'source' in res
 
 
-def test_open_and_enter_game_block_success() -> None:
+def test_open_game_block_success_enter_true() -> None:
     backend = _mock_backend()
     fut: Future = Future()
     fut.set_result(OperationResult(success=True, status='成功'))
     backend.start_run.return_value = (True, fut)
-    tool = app_mod.make_open_and_enter_game(backend)
-    assert asyncio.run(tool(block=True)) == '成功打开并进入绝区零游戏'
+    tool = app_mod.make_open_game(backend)
+    assert asyncio.run(tool(enter=True, block=True)) == '成功打开并进入绝区零游戏'
 
 
-def test_open_and_enter_game_block_failed() -> None:
+def test_open_game_block_success_enter_false() -> None:
+    """enter=False 成功 → 返回「打开游戏(未登录)」文案。"""
+    backend = _mock_backend()
+    fut: Future = Future()
+    fut.set_result(OperationResult(success=True, status='成功'))
+    backend.start_run.return_value = (True, fut)
+    tool = app_mod.make_open_game(backend)
+    assert asyncio.run(tool(enter=False, block=True)) == '成功打开游戏(未登录)'
+
+
+def test_open_game_block_failed() -> None:
     backend = _mock_backend()
     fut: Future = Future()
     fut.set_result(OperationResult(success=False, status='打开游戏失败'))
     backend.start_run.return_value = (True, fut)
-    tool = app_mod.make_open_and_enter_game(backend)
-    assert asyncio.run(tool(block=True)) == '打开游戏失败: 打开游戏失败'
+    tool = app_mod.make_open_game(backend)
+    assert asyncio.run(tool(enter=True, block=True)) == '打开游戏失败: 打开游戏失败'
+
+
+def test_open_game_enter_false_selects_open_game_op() -> None:
+    """enter=False 时传给 start_run 的 op_factory 构造出的是 OpenGame(非 OpenAndEnterGame)。冒烟验证 Task 1 重构。"""
+    from unittest.mock import MagicMock
+    from zzz_od.operation.enter_game.open_game import OpenGame
+
+    backend = _mock_backend()
+    tool = app_mod.make_open_game(backend)
+    asyncio.run(tool(enter=False, block=False))
+    op_factory = backend.start_run.call_args[0][1]
+    op = op_factory(MagicMock(name='ZContext'))
+    assert isinstance(op, OpenGame)
+
+
+def test_open_game_enter_true_selects_open_and_enter_game_op() -> None:
+    """enter=True 时 op_factory 构造出的是 OpenAndEnterGame。"""
+    from unittest.mock import MagicMock
+    from zzz_od.operation.enter_game.open_and_enter_game import OpenAndEnterGame
+
+    backend = _mock_backend()
+    tool = app_mod.make_open_game(backend)
+    asyncio.run(tool(enter=True, block=False))
+    op_factory = backend.start_run.call_args[0][1]
+    op = op_factory(MagicMock(name='ZContext'))
+    assert isinstance(op, OpenAndEnterGame)
 
 
 def test_get_run_status_delegates() -> None:
@@ -213,3 +252,39 @@ def test_stop_run_delegates() -> None:
     res = app_mod.make_stop_run(backend)()
     assert res['stopped'] is False
     backend.stop.assert_called_once()
+
+
+# ===== click_game / input_text 工具(内联注册,同 close_game) =====
+
+def test_click_game_tool_registered() -> None:
+    mcp, _ = _mcp_with_backend()
+    tools = asyncio.run(mcp.list_tools())
+    assert any(t.name == "click_game" for t in tools)
+
+
+def test_click_game_tool_delegates() -> None:
+    """click_game tool 直调 backend.click_game() 并原样返回。"""
+    mcp, backend = _mcp_with_backend()
+    backend.click_game.return_value = {'success': True, 'x': 960, 'y': 540, 'in_window': True}
+    tool = mcp._tool_manager._tools['click_game']
+    fn = getattr(tool, 'fn', None) or getattr(tool, 'func', None)
+    result = fn(x=960, y=540)
+    backend.click_game.assert_called_once_with(960, 540, 0.0)
+    assert result['success'] is True
+
+
+def test_input_text_tool_registered() -> None:
+    mcp, _ = _mcp_with_backend()
+    tools = asyncio.run(mcp.list_tools())
+    assert any(t.name == "input_text" for t in tools)
+
+
+def test_input_text_tool_delegates() -> None:
+    """input_text tool 直调 backend.input_text() 并原样返回。"""
+    mcp, backend = _mcp_with_backend()
+    backend.input_text.return_value = {'success': True, 'method': 'clipboard', 'masked_text': '***'}
+    tool = mcp._tool_manager._tools['input_text']
+    fn = getattr(tool, 'fn', None) or getattr(tool, 'func', None)
+    result = fn(text='abc', use_clipboard=True)
+    backend.input_text.assert_called_once_with('abc', True)
+    assert result['method'] == 'clipboard'

--- a/test/zzz_od/backend/test_mcp_app.py
+++ b/test/zzz_od/backend/test_mcp_app.py
@@ -288,3 +288,15 @@ def test_input_text_tool_delegates() -> None:
     result = fn(text='abc', use_clipboard=True)
     backend.input_text.assert_called_once_with('abc', True)
     assert result['method'] == 'clipboard'
+
+
+def test_analyze_screen_tool_passes_save_image() -> None:
+    """analyze_screen tool 应把 save_image 透传给 backend.analyze,并回带 screenshot_path。"""
+    mcp, backend = _mcp_with_backend()
+    backend.analyze.return_value = AnalyzeScreenResult(
+        success=True, ocr_texts=[], error=None, screenshot_path='/tmp/x.png')
+    tool = mcp._tool_manager._tools['analyze_screen']
+    fn = getattr(tool, 'fn', None) or getattr(tool, 'func', None)
+    result = fn(save_image=True)
+    backend.analyze.assert_called_once_with(None, True)
+    assert result.screenshot_path == '/tmp/x.png'

--- a/test/zzz_od/backend/test_schemas.py
+++ b/test/zzz_od/backend/test_schemas.py
@@ -71,7 +71,5 @@ def test_run_status_result_defaults() -> None:
 
 def test_analyze_result_default_screenshot_path_none() -> None:
     """AnalyzeScreenResult 默认 screenshot_path=None。"""
-    from zzz_od.backend.schemas import AnalyzeScreenResult
-
     r = AnalyzeScreenResult(success=True, ocr_texts=[], error=None)
     assert r.screenshot_path is None

--- a/test/zzz_od/backend/test_schemas.py
+++ b/test/zzz_od/backend/test_schemas.py
@@ -67,3 +67,11 @@ def test_run_status_result_defaults() -> None:
     r = RunStatusResult(state='idle')
     assert r.source is None and r.app is None
     assert r.current_node is None and r.last_status is None and r.failed_node is None
+
+
+def test_analyze_result_default_screenshot_path_none() -> None:
+    """AnalyzeScreenResult 默认 screenshot_path=None。"""
+    from zzz_od.backend.schemas import AnalyzeScreenResult
+
+    r = AnalyzeScreenResult(success=True, ocr_texts=[], error=None)
+    assert r.screenshot_path is None


### PR DESCRIPTION
配套主仓 PR [OneDragon-Anything/ZenlessZoneZero-OneDragon#2450](https://github.com/OneDragon-Anything/ZenlessZoneZero-OneDragon/pull/2450) 的测试。

- `test_click_game.py`(新增,4):click_game 委托 controller.click(Point,press_time)/出窗口 False/未就绪 raise/默认 press_time=0
- `test_input_text.py`(新增,6):剪贴板/逐键 强制覆盖 + 跟 `type_input_way` 配置 + 脱敏 + 未就绪 raise
- `test_mcp_app.py`(改):`open_and_enter_game` 组 → `open_game(enter)` 组(7,含 enter 选 op 的 isinstance 冒烟)+ `click_game`/`input_text` tool 注册与委托

Point 无 `__eq__`,坐标断言用字段比较 `(call.args[0].x, call.args[0].y)`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * 新增并扩展了后端点击、文本输入相关的单元测试，覆盖成功、失败、未就绪、默认参数和结果字段等场景。
  * 更新了 MCP 工具注册与转发测试，验证新工具可正常暴露并调用。
  * 补充了打开游戏相关流程的工厂委托测试，覆盖不同参数组合下的行为。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->