### PR TITLE
test(screen_loader): 移除 btn_switch_backup_1 的 xfail(strict) 标记(配合主仓 #2470)

### DIFF
--- a/test/one_dragon/base/screen/screen_loader/test_screen_info_template_exist.py
+++ b/test/one_dragon/base/screen/screen_loader/test_screen_info_template_exist.py
@@ -1,5 +1,3 @@
-import pytest
-
 from test.conftest import TestContext
 
 
@@ -10,7 +8,6 @@ class TestScreenInfoTemplateExist:
     ``template_sub_dir`` 跨整个 ``assets/template/``)。证明「被画面引用的模板都存在且能读」。
     """
 
-    @pytest.mark.xfail(reason='已知:battle/btn_switch_backup_1 模板缺失,见 issue #2463', strict=True)
     def test_screen_info_template(self, test_context: TestContext):
         missing = []
         for screen_info in test_context.screen_loader.screen_info_list:


### PR DESCRIPTION
## 背景

主仓 PR [ZenlessZoneZero-OneDragon#2470](https://github.com/OneDragon-Anything/ZenlessZoneZero-OneDragon/pull/2470) 删除了战斗画面「按键-切换后援」 area(其引用了缺失模板 `battle/btn_switch_backup_1`),修复 issue [#2463](https://github.com/OneDragon-Anything/ZenlessZoneZero-OneDragon/issues/2463)。

## 本 PR

移除 `test_screen_info_template_exist.py::test_screen_info_template` 上的 `@pytest.mark.xfail(strict=True)`(及随之未使用的 `import pytest`)。

**原因**:issue #2463 修复后该测试不再 fail;`strict=True` 下通过的 xfail 会翻转为 `FAILED`,反而卡住主仓 #2470 的 test-check。issue 原文亦注明「待本 issue 修复后去掉标记」。

## CI 联动

主仓 `test-check` 用 PR head 分支名到测试仓 checkout **同名分支**(先查 fork,fallback upstream)。本分支 `chore/remove-unused-switch-backup-area` 与主仓 #2470 head 同名,push 到 upstream 后 CI fallback 即可命中。

## 验证

- main 状态(仍含缺失 area):测试如实 `FAILED`(标记移除生效,不再是 xfail)
- 模拟 #2470(删 `_od_merged.yml` 该 area):测试 `PASSED`