### PR TITLE
chore: 测试统一使用 ppocrv6 OCR 模型

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -198,6 +198,8 @@ def test_context() -> TestContext:
 
     ctx.env_config.is_debug = True
     ctx.current_instance_idx = 99  # 使用特定的实例id
+    # 测试统一使用 ppocrv6(识别更准;CI 与本地一致,避免 ppocrv5 把 "99" 识别成 "9" 等)
+    ctx.model_config.ocr = 'ppocrv6'
     ctx.init()
     ctx.controller = MockController(
         game_config=ctx.game_config,


### PR DESCRIPTION
## 背景

CI 跑测试时无 OCR 配置，走主仓默认（现 `ppocrv5`）。ppocrv5 把电量识别里的 `"99"` 识别成 `"9"`，导致 `test_check_battery_charge` 的 `sample_322_01`（期望 `(181, 99, 50)`）在 CI 失败，main 的 test-check 一直红（主仓 #2348）。

## 改动

`conftest.py` 的 session fixture 在 `ctx.init()` 前设 `ctx.model_config.ocr = 'ppocrv6'`，让整个测试 session 统一用 ppocrv6（识别更准）：

```python
ctx.current_instance_idx = 99
ctx.model_config.ocr = 'ppocrv6'   # init_ocr 据此加载 v6
ctx.init()
```

机制：`init_ocr()` 读 `model_config.ocr` 决定模型 + 自动下载缺失模型；`model_config` 是 `@cached_property`，`TestContext()` 构造时已创建，故 init 前可改。

## 验证

本地全量 `pytest zzz-od-test/ -m "not requires_secrets"`：**328 passed, 1 skipped, 0 failed**（含主仓 #2348 的 sample_322_01）。

## 设计权衡（为什么不改主仓默认）

只让**测试环境**用 v6，**不碰主仓默认模型**（仍 `ppocrv5`）→ 不影响真实用户的下载/运行流程。主仓默认切 v6（主仓 #2515）因下载逻辑缺自动多源 fallback、有卡死新用户的风险（见 #2515 @ShadowLemoon 评审），待资源下载逻辑重构后再议。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **测试**
  - 统一测试环境中的 OCR 识别配置，提升本地与持续集成环境结果的一致性。
  - 减少因 OCR 版本差异导致的数字识别错误，增强测试稳定性与可靠性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->