### PR TITLE
test(backend): run_operation 数据类参数反序列化测试(配套主仓 #2561)

### DIFF
--- a/test/zzz_od/backend/test_mcp_app.py
+++ b/test/zzz_od/backend/test_mcp_app.py
@@ -268,6 +268,7 @@ def test_open_game_block_failed() -> None:
 def test_open_game_enter_false_selects_open_game_op() -> None:
     """enter=False 时传给 start_run 的 op_factory 构造出的是 OpenGame(非 OpenAndEnterGame)。冒烟验证 Task 1 重构。"""
     from unittest.mock import MagicMock
+
     from zzz_od.operation.enter_game.open_game import OpenGame
 
     backend = _mock_backend()
@@ -281,6 +282,7 @@ def test_open_game_enter_false_selects_open_game_op() -> None:
 def test_open_game_enter_true_selects_open_and_enter_game_op() -> None:
     """enter=True 时 op_factory 构造出的是 OpenAndEnterGame。"""
     from unittest.mock import MagicMock
+
     from zzz_od.operation.enter_game.open_and_enter_game import OpenAndEnterGame
 
     backend = _mock_backend()
@@ -510,3 +512,29 @@ def test_run_operation_bakes_args_into_factory() -> None:
     assert isinstance(op, MapTransport)
     assert op.area_name == '六分街'
     assert op.tp_name == '黑糖工作室'
+
+
+def test_run_operation_coerces_dataclass_param() -> None:
+    """``@dataclass``+``from_dict`` 参数(plan)从 dict 反序列化:传 dict → started=True(不再拒),op_factory 构造后 plan 是实例。"""
+    from zzz_od.application.charge_plan.charge_plan_config import ChargePlanItem
+    from zzz_od.backend.mcp.service_app import make_run_operation
+    from zzz_od.operation.compendium.notorious_hunt import NotoriousHunt
+
+    backend = MagicMock()
+    backend.run_slot._start.return_value = (True, Future())
+    backend.query_status.return_value = RunStatusResult(state='running', source='mcp')
+    res = asyncio.run(make_run_operation(backend)(
+        op_id=_NOTORIOUS,
+        args={'plan': {'category_name': '恶名狩猎', 'plan_times': 2}},
+        block=False,
+    ))
+    # 传 dict → 不再被拒(coercible),started=True
+    assert res['started'] is True
+    # op_factory 构造出 NotoriousHunt,plan 被 coerce 成 ChargePlanItem 实例
+    call = backend.run_slot._start.call_args
+    op_factory = call.kwargs.get('op_factory') or call.args[1]
+    op = op_factory(MagicMock(name='ZContext'))
+    assert isinstance(op, NotoriousHunt)
+    assert isinstance(op.plan, ChargePlanItem)
+    assert op.plan.category_name == '恶名狩猎'
+    assert op.plan.plan_times == 2

--- a/test/zzz_od/backend/test_operation_registry.py
+++ b/test/zzz_od/backend/test_operation_registry.py
@@ -160,6 +160,16 @@ def test_validate_args_coercible_dataclass(mock_ctx: MagicMock) -> None:
     assert validate_args(NotoriousHunt, {'plan': {'mission_type_name': 'x'}}) is None
 
 
+def test_validate_args_coercible_requires_dict(mock_ctx: MagicMock) -> None:
+    """coercible 参数(ChargePlanItem)值必须是 dict;标量/列表/None 拒绝(否则绕过 coerce,错误类型进 op 构造)。"""
+    from zzz_od.operation.compendium.notorious_hunt import NotoriousHunt
+    for bad in ([], '字符串', None, 42):
+        err = validate_args(NotoriousHunt, {'plan': bad})
+        assert err is not None, f'{bad!r} 应被拒'
+        assert 'plan' in err
+        assert 'dict' in err
+
+
 def test_validate_args_accepts_no_extra_params(mock_ctx: MagicMock) -> None:
     """只有 ctx 参数的 op(如 OpenAndEnterGame),空 args → None。"""
     from zzz_od.operation.enter_game.open_and_enter_game import OpenAndEnterGame

--- a/test/zzz_od/backend/test_operation_registry.py
+++ b/test/zzz_od/backend/test_operation_registry.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from zzz_od.backend.operation_registry import (
+    coerce_dataclass_params,
     describe_operation,
     resolve_op_class,
     scan_operations,
@@ -46,7 +47,6 @@ def test_scan_includes_concrete_hollow_event_ops(mock_ctx: MagicMock) -> None:
 def test_scan_excludes_application_subclasses_and_bases(mock_ctx: MagicMock) -> None:
     """排除:Application 子类(RedemptionCodeApp 等)+ 显式抽象基类 + *Base 后缀。"""
     result = scan_operations(mock_ctx, refresh=True)
-    op_ids = [o.op_id for o in result.operations]
     class_names = {o.class_name for o in result.operations}
 
     # 显式抽象/中间基类不出现
@@ -149,22 +149,46 @@ def test_validate_args_rejects_missing_required(mock_ctx: MagicMock) -> None:
     assert 'tp_name' in err
 
 
-def test_validate_args_rejects_complex_dataclass(mock_ctx: MagicMock) -> None:
-    """NotoriousHunt 必填 plan: ChargePlanItem(复杂数据类)→ 无论是否传值都拒绝。"""
+def test_validate_args_coercible_dataclass(mock_ctx: MagicMock) -> None:
+    """NotoriousHunt 必填 plan: ChargePlanItem(@dataclass+from_dict)→ 缺参拒;传 dict 接受(可反序列化)。"""
     from zzz_od.operation.compendium.notorious_hunt import NotoriousHunt
-    # 缺参 → 拒
+    # 缺必填 → 拒
     err_missing = validate_args(NotoriousHunt, {})
     assert err_missing is not None
-    # 传了值但类型是复杂数据类 → 仍拒绝
-    err_complex = validate_args(NotoriousHunt, {'plan': {'mission_type_name': 'x'}})
-    assert err_complex is not None
-    assert 'plan' in err_complex
+    assert 'plan' in err_missing
+    # 传 dict → 接受(coercible:实例化前用 from_dict 反序列化)
+    assert validate_args(NotoriousHunt, {'plan': {'mission_type_name': 'x'}}) is None
 
 
 def test_validate_args_accepts_no_extra_params(mock_ctx: MagicMock) -> None:
     """只有 ctx 参数的 op(如 OpenAndEnterGame),空 args → None。"""
     from zzz_od.operation.enter_game.open_and_enter_game import OpenAndEnterGame
     assert validate_args(OpenAndEnterGame, {}) is None
+
+
+# ---------- coerce_dataclass_params ----------
+
+def test_coerce_dataclass_params_converts_dict() -> None:
+    """@dataclass+from_dict 参数的 dict 值 → 反序列化为实例。"""
+    from zzz_od.application.charge_plan.charge_plan_config import ChargePlanItem
+    from zzz_od.operation.compendium.notorious_hunt import NotoriousHunt
+    coerced = coerce_dataclass_params(
+        NotoriousHunt, {'plan': {'category_name': '恶名狩猎', 'plan_times': 2}},
+    )
+    assert isinstance(coerced['plan'], ChargePlanItem)
+    assert coerced['plan'].category_name == '恶名狩猎'
+    assert coerced['plan'].plan_times == 2
+
+
+def test_coerce_dataclass_params_passthrough_non_dict() -> None:
+    """非 coercible 参数原样保留;返回新 dict(不就地改入参)。"""
+    from zzz_od.operation.map_transport import MapTransport
+    args = {'area_name': '六分街', 'tp_name': '黑糖工作室'}
+    coerced = coerce_dataclass_params(MapTransport, args)
+    # 标量参数原样
+    assert coerced == args
+    # 不就地改入参(返回新 dict)
+    assert coerced is not args
 
 
 # ---------- describe_operation ----------
@@ -182,13 +206,14 @@ def test_describe_operation_reflects_params(mock_ctx: MagicMock) -> None:
     assert info['debuggable'] is True
 
 
-def test_describe_operation_marks_complex_param(mock_ctx: MagicMock) -> None:
-    """复杂数据类参数(ChargePlanItem)标 json_serializable=False、debuggable=False。"""
+def test_describe_operation_marks_coercible_param(mock_ctx: MagicMock) -> None:
+    """@dataclass+from_dict 参数(ChargePlanItem)标 json_serializable=False、coercible=True、debuggable=True。"""
     info = describe_operation(
         mock_ctx, 'zzz_od.operation.compendium.notorious_hunt.NotoriousHunt',
     )
     plan = next(p for p in info['params'] if p['name'] == 'plan')
     assert plan['required'] is True
     assert plan['json_serializable'] is False
-    # 存在不可序列化的必填参 → debuggable=False
-    assert info['debuggable'] is False
+    assert plan['coercible'] is True
+    # coercible 参数可从 dict 传 → debuggable=True
+    assert info['debuggable'] is True


### PR DESCRIPTION
## 配套主仓 PR

OneDragon-Anything/ZenlessZoneZero-OneDragon#2561 `feat(backend): run_operation 支持 @dataclass+from_dict 参数从 dict 反序列化`

## 测试改动

对应主仓方案 A + review 修复:
- `test_operation_registry.py`:`_annotation_coercible` 判定 / `coerce_dataclass_params` 转换+透传 / `validate_args` 放行 coercible / `describe` 标 coercible / **coercible 参数必须 dict 负向测试**(CodeRabbit review 修复)
- `test_mcp_app.py`:`run_operation` 传 plan dict → started=True + op_factory 构造 + plan 是 ChargePlanItem 实例(端到端)

## 合并顺序

配套主仓 #2561,**测试仓先合 → 主仓后合**(主仓 main 的 test-check clone 测试仓 main)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)