### PR TITLE
test(lost_void): 补玛琳偶遇事件过滤回归测试

### DIFF
--- a/test/zzz_od/application/hollow_zero/lost_void/test_handle_interact_route.py
+++ b/test/zzz_od/application/hollow_zero/lost_void/test_handle_interact_route.py
@@ -1,24 +1,4 @@
-"""LostVoidRunLevel.handle_interact 画面路由测试。
-
-按 testing methodology 动作一:``handle_interact`` 按 ``check_and_update_current_screen``
-识别出的画面名,路由到不同子 op 或直接返回 round_success。本文件覆盖两类分支:
-
-1. 子 op 分支(武备选择 / 通用选择 / 邦布商店 / 路径迭换 / 抽奖机):
-   patch 子 op 类的 ``execute`` 返回固定成功结果 → 调 ``handle_interact`` →
-   断言子 op 被调用、``had_been_list`` 是否按 interact_type 追加、``round_wait`` 透传 status。
-
-2. 直接返回分支(挑战结果 / 大世界):
-   无子 op,直接断言 ``round_success`` 的 status。
-
-所有用例使用的 fixture 均已存在 → 全部 GREEN。
-
-源码行为(已读 ``lost_void_run_level.py`` 的 ``handle_interact`` 确认):
-- 武备选择 / 通用选择:``interact_type`` 保持 ``None``,子 op 成功后不追加 ``had_been_list``。
-- 邦布商店 / 路径迭换:``interact_type`` 分别为 ``邦布商店`` / ``路径迭换``,成功后追加。
-- 抽奖机:``interact_type`` 被设为 ``邦布商店``(源码 TODO:1.6 新增的抽奖机图标会被误判成
-  商店,等待后续模型更新),成功后同样追加 ``邦布商店``。
-- 挑战结果 → ``round_success('迷失之地-挑战结果')``;大世界 → ``round_success('迷失之地-大世界')``。
-"""
+"""LostVoidRunLevel.handle_interact 画面路由与入口过滤登记测试。"""
 from unittest.mock import patch
 
 import pytest
@@ -44,79 +24,71 @@ from zzz_od.application.hollow_zero.lost_void.operation.interact.lost_void_route
     LostVoidRouteChange,
 )
 from zzz_od.application.hollow_zero.lost_void.operation.lost_void_run_level import (
+    LostVoidLevelInteractionState,
     LostVoidRunLevel,
 )
 
 
 def _make_op(test_context: TestContext) -> LostVoidRunLevel:
-    """构造一个 ``LostVoidRunLevel`` 实例(用 ENTRY 区域类型,handle_interact 不依赖它)。"""
-    return LostVoidRunLevel(test_context, LostVoidRegionType.ENTRY)
+    """构造 handle_interact 所需的操作实例。"""
+    return LostVoidRunLevel(
+        test_context,
+        LostVoidRegionType.ENTRY,
+        LostVoidLevelInteractionState(),
+    )
 
 
-# 子 op 分支:(画面名, fixture state, 子 op 类, 期望 append 到 had_been_list 的 interact_type 或 None)
-# 5 个 fixture 均已有 → GREEN。
-SUB_OP_CASES: list[tuple[str, str, type, str | None]] = [
-    ('迷失之地-武备选择', '初始战术棱镜方案', LostVoidChooseGear, None),
-    ('迷失之地-通用选择', '选1张卡牌', LostVoidChooseCommon, None),
-    ('迷失之地-邦布商店', '商店', LostVoidBangbooStore, '邦布商店'),
-    ('迷失之地-路径迭换', '选定位卡', LostVoidRouteChange, '路径迭换'),
-    ('迷失之地-抽奖机', '抽奖前', LostVoidLottery, '邦布商店'),  # TODO 抽奖机图标被误判为商店
+SUB_OP_CASES: list[tuple[str, type, str | None]] = [
+    ('迷失之地-武备选择', LostVoidChooseGear, None),
+    ('迷失之地-通用选择', LostVoidChooseCommon, None),
+    ('迷失之地-邦布商店', LostVoidBangbooStore, '邦布商店'),
+    ('迷失之地-路径迭换', LostVoidRouteChange, '路径迭换'),
+    ('迷失之地-抽奖机', LostVoidLottery, '邦布商店'),  # TODO 抽奖机图标被误判成商店
 ]
 
 
 @pytest.mark.parametrize(
-    'screen_name, state, sub_op_cls, expected_interact_type', SUB_OP_CASES,
-    ids=[c[1] for c in SUB_OP_CASES],
+    'screen_name, sub_op_cls, expected_interact_type',
+    SUB_OP_CASES,
+    ids=[case[0] for case in SUB_OP_CASES],
 )
 def test_handle_interact_routes_to_sub_op(
-    test_context: TestContext, screen_name: str, state: str,
-    sub_op_cls: type, expected_interact_type: str | None,
+    test_context: TestContext,
+    screen_name: str,
+    sub_op_cls: type,
+    expected_interact_type: str | None,
 ) -> None:
-    """画面命中 → 实例化对应子 op 并 execute;成功后按 interact_type 决定是否追加 had_been_list。"""
+    """识别到子页面后执行对应操作，并登记需要过滤的入口类型。"""
     op = _make_op(test_context)
-    test_context.mock_screen(screen_name, state)
-    op.screenshot()
-
     mock_result = OperationResult(success=True, status='mocked')
-    with patch.object(sub_op_cls, 'execute', return_value=mock_result) as mock_execute:
+    with (patch.object(op, 'check_and_update_current_screen', return_value=screen_name),
+          patch.object(sub_op_cls, 'execute', return_value=mock_result) as mock_execute):
         result = op.handle_interact()
 
-    # 子 op.execute 被路由调用
-    assert mock_execute.called, f'{state}: 应调用 {sub_op_cls.__name__}.execute'
-    # 子 op 成功后,handle_interact 返回 round_wait 并透传子 op status
-    assert result.status == 'mocked', f'{state}: 应透传子 op status'
-    # interact_type 非 None 时追加 had_been_list;为 None 时不追加
-    if expected_interact_type is None:
-        assert op.had_been_list == [], f'{state}: interact_type 为 None 不应追加 had_been_list'
-    else:
-        assert op.had_been_list == [expected_interact_type], (
-            f'{state}: had_been_list 应追加 {expected_interact_type}'
-        )
+    assert mock_execute.called, f'{screen_name}: 应调用 {sub_op_cls.__name__}.execute'
+    assert result.status == 'mocked', f'{screen_name}: 应透传子操作状态'
+    expected_ignored_entry_name_set = (
+        set() if expected_interact_type is None else {expected_interact_type}
+    )
+    assert op.level_interaction_state.ignored_entry_name_set == expected_ignored_entry_name_set
 
 
-# 直接返回分支:(画面名, fixture state, 期望 round_success 的 status)
-# 4 个 fixture 均已有 → GREEN。
-DIRECT_CASES: list[tuple[str, str, str]] = [
-    ('迷失之地-挑战结果', '奖励展示态', '迷失之地-挑战结果'),
-    ('迷失之地-挑战结果', '完成态', '迷失之地-挑战结果'),
-    ('迷失之地-挑战结果', '确定态', '迷失之地-挑战结果'),
-    ('迷失之地-大世界', '玛琳前-以太稳定', '迷失之地-大世界'),
+DIRECT_CASES: list[tuple[str, str]] = [
+    ('迷失之地-挑战结果', '迷失之地-挑战结果'),
+    ('迷失之地-大世界', '迷失之地-大世界'),
 ]
 
 
-@pytest.mark.parametrize(
-    'screen_name, state, expected_status', DIRECT_CASES,
-    ids=[c[1] for c in DIRECT_CASES],
-)
+@pytest.mark.parametrize('screen_name, expected_status', DIRECT_CASES)
 def test_handle_interact_direct_success(
-    test_context: TestContext, screen_name: str, state: str, expected_status: str,
+    test_context: TestContext,
+    screen_name: str,
+    expected_status: str,
 ) -> None:
-    """挑战结果 / 大世界分支无子 op,直接 round_success 返回固定 status。"""
+    """挑战结果和大世界画面直接返回对应状态。"""
     op = _make_op(test_context)
-    test_context.mock_screen(screen_name, state)
-    op.screenshot()
+    with patch.object(op, 'check_and_update_current_screen', return_value=screen_name):
+        result = op.handle_interact()
 
-    result = op.handle_interact()
-
-    assert result.is_success, f'{state}: 应返回 round_success'
-    assert result.status == expected_status, f'{state}: status 应为 {expected_status}'
+    assert result.is_success
+    assert result.status == expected_status

--- a/test/zzz_od/application/hollow_zero/lost_void/test_ma_lin_encounter_filter.py
+++ b/test/zzz_od/application/hollow_zero/lost_void/test_ma_lin_encounter_filter.py
@@ -1,0 +1,118 @@
+"""玛琳交互后的偶遇事件入口过滤测试。"""
+from types import SimpleNamespace
+
+import pytest
+
+import zzz_od.application.hollow_zero.lost_void.lost_void_app as lost_void_app_module
+from one_dragon.base.operation.operation_base import OperationResult
+from zzz_od.application.hollow_zero.lost_void.context.lost_void_context import (
+    LostVoidContext,
+)
+from zzz_od.application.hollow_zero.lost_void.context.lost_void_det_class import (
+    LostVoidDetClass,
+)
+from zzz_od.application.hollow_zero.lost_void.lost_void_app import LostVoidApp
+from zzz_od.application.hollow_zero.lost_void.lost_void_challenge_config import (
+    LostVoidRegionType,
+)
+from zzz_od.application.hollow_zero.lost_void.operation.interact.lost_void_interact_target_const import (
+    LostVoidInteractNPC,
+    LostVoidInteractTarget,
+)
+from zzz_od.application.hollow_zero.lost_void.operation.lost_void_run_level import (
+    LostVoidLevelInteractionState,
+    LostVoidRunLevel,
+)
+
+
+class _FakeDetector:
+    """仅记录 detect_to_go 实际下发的 YOLO 标签。"""
+
+    def __init__(self) -> None:
+        self.idx_2_class: dict[int, LostVoidDetClass] = {
+            0: LostVoidDetClass(0, '0007-偶遇事件'),
+            1: LostVoidDetClass(1, '0010-邦布商店'),
+        }
+
+    def run(self, screen: object, run_time: float, label_list: list[str] | None) -> list[str]:
+        if label_list is None:
+            return [det_class.class_name for det_class in self.idx_2_class.values()]
+        return label_list
+
+
+def _detect_entry_labels(state: LostVoidLevelInteractionState) -> list[str]:
+    """通过真实 detect_to_go 标签筛选逻辑返回允许的 YOLO 标签。"""
+    detector = _FakeDetector()
+    lost_void_context = object.__new__(LostVoidContext)
+    lost_void_context.detector = detector
+    lost_void_context.ctx = SimpleNamespace(
+        lost_void=SimpleNamespace(detector=detector),
+    )
+    return lost_void_context.detect_to_go(
+        screen=None,
+        screenshot_time=0,
+        ignore_list=state.ignored_entry_name_list,
+    )
+
+
+def _run_level_with_status(
+    app: LostVoidApp,
+    status: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> OperationResult:
+    """直接运行 App 的状态处理分支，不执行真实层间移动。"""
+
+    class FakeLostVoidRunLevel:
+        STATUS_NEXT_LEVEL = LostVoidRunLevel.STATUS_NEXT_LEVEL
+        STATUS_COMPLETE = LostVoidRunLevel.STATUS_COMPLETE
+
+        def __init__(
+            self,
+            ctx: object,
+            region_type: LostVoidRegionType,
+            level_interaction_state: LostVoidLevelInteractionState,
+        ) -> None:
+            assert level_interaction_state is app.level_interaction_state
+
+        def execute(self) -> OperationResult:
+            return OperationResult(success=True, status=status)
+
+    monkeypatch.setattr(lost_void_app_module, 'LostVoidRunLevel', FakeLostVoidRunLevel)
+    return app.run_level()
+
+
+def test_ma_lin_encounter_entry_is_filtered_until_next_level(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """玛琳完成后过滤偶遇；普通重进层间移动不清空，进入下一层才重置。"""
+    state = LostVoidLevelInteractionState()
+    op = object.__new__(LostVoidRunLevel)
+    op.level_interaction_state = state
+    op.locked_interact_target = LostVoidInteractTarget(
+        name=LostVoidInteractNPC.MA_LIN.value,
+        icon='感叹号',
+        is_npc=True,
+    )
+    op.interact_target = LostVoidInteractTarget(
+        name='未知',
+        icon='感叹号',
+        is_exclamation=True,
+    )
+
+    op.mark_locked_interact_completed()
+    assert '0007-偶遇事件' not in _detect_entry_labels(state)
+    assert '0010-邦布商店' in _detect_entry_labels(state)
+
+    app = object.__new__(LostVoidApp)
+    app.ctx = SimpleNamespace(
+        lost_void=SimpleNamespace(had_interacted_ophelia_on_current_level=False),
+    )
+    app.next_region_type = LostVoidRegionType.ENTRY
+    app.level_interaction_state = state
+    app.round_by_op_result = lambda result: result
+
+    _run_level_with_status(app, '非战斗区域', monkeypatch)
+    assert '0007-偶遇事件' not in _detect_entry_labels(state)
+
+    _run_level_with_status(app, LostVoidRunLevel.STATUS_NEXT_LEVEL, monkeypatch)
+    assert '0007-偶遇事件' in _detect_entry_labels(state)

--- a/test/zzz_od/application/hollow_zero/lost_void/test_run_level_append_priority.py
+++ b/test/zzz_od/application/hollow_zero/lost_void/test_run_level_append_priority.py
@@ -17,31 +17,45 @@
 - 已在优先级 → 不重复加。
 - 不在队伍的类型 → 加入 dynamic_abandon_list(除非被 specific priority rule 保护)。
 """
+from types import SimpleNamespace
 from unittest.mock import patch
 
+import pytest
 from test.conftest import TestContext
 
 from zzz_od.application.hollow_zero.lost_void.lost_void_challenge_config import (
     LostVoidRegionType,
 )
 from zzz_od.application.hollow_zero.lost_void.operation.lost_void_run_level import (
+    LostVoidLevelInteractionState,
     LostVoidRunLevel,
 )
 from zzz_od.auto_battle.auto_battle_agent_context import AgentInfo, TeamInfo
 from zzz_od.game_data.agent import AgentEnum, AgentTypeEnum
 
 
+@pytest.fixture(autouse=True)
+def restore_challenge_config(test_context: TestContext):
+    """测试结束后恢复 session 级上下文中的挑战配置。"""
+    challenge_config = test_context.lost_void.challenge_config
+    yield
+    test_context.lost_void.challenge_config = challenge_config
+
+
 def _setup_op(test_context: TestContext) -> LostVoidRunLevel:
-    """构造 LostVoidRunLevel 实例并重置 lost_void 上下文 dynamic 列表。"""
+    """构造使用内存挑战配置的 LostVoidRunLevel 实例。"""
     test_context.lost_void.load_artifact_data()
-    test_context.lost_void.load_challenge_config()
-    # 清空 challenge_config 中可能残留的 specific 优先级规则,避免影响 abandon 判定
-    test_context.lost_void.challenge_config.artifact_priority = []
-    test_context.lost_void.challenge_config.artifact_priority_2 = []
-    test_context.lost_void.challenge_config.clear_artifact_priority_in_battle()
+    test_context.lost_void.challenge_config = SimpleNamespace(
+        artifact_priority_in_battle=[],
+        artifact_priority_2=[],
+    )
     test_context.lost_void.dynamic_priority_list = []
     test_context.lost_void.dynamic_abandon_list = []
-    return LostVoidRunLevel(test_context, LostVoidRegionType.ENTRY)
+    return LostVoidRunLevel(
+        test_context,
+        LostVoidRegionType.ENTRY,
+        LostVoidLevelInteractionState(),
+    )
 
 
 def _set_team(test_context: TestContext, agents: list[AgentEnum]) -> None:
@@ -107,7 +121,6 @@ def test_specific_priority_rule_protects_abandon(test_context: TestContext) -> N
     op = _setup_op(test_context)
     # artifact_priority_2 含 specific 规则「异常 某某藏品」→ category「异常」受保护
     test_context.lost_void.challenge_config.artifact_priority_2 = ['异常 某某藏品']
-    test_context.lost_void.challenge_config.clear_artifact_priority_in_battle()
     _set_team(test_context, [AgentEnum.ELLEN])  # 只在强攻,异常不在队伍
     _run_append(op)
     assert '异常' not in test_context.lost_void.dynamic_abandon_list, \
@@ -118,7 +131,6 @@ def test_pure_category_rule_does_not_protect(test_context: TestContext) -> None:
     """纯分类规则(如「异常」,无具体名)不视为 specific,不保护 abandon。"""
     op = _setup_op(test_context)
     test_context.lost_void.challenge_config.artifact_priority_2 = ['异常']
-    test_context.lost_void.challenge_config.clear_artifact_priority_in_battle()
     _set_team(test_context, [AgentEnum.ELLEN])
     _run_append(op)
     assert '异常' in test_context.lost_void.dynamic_abandon_list, \

--- a/test/zzz_od/application/hollow_zero/lost_void/test_run_level_init_region_type.py
+++ b/test/zzz_od/application/hollow_zero/lost_void/test_run_level_init_region_type.py
@@ -16,6 +16,7 @@ from zzz_od.application.hollow_zero.lost_void.lost_void_challenge_config import 
     LostVoidRegionType,
 )
 from zzz_od.application.hollow_zero.lost_void.operation.lost_void_run_level import (
+    LostVoidLevelInteractionState,
     LostVoidRunLevel,
 )
 
@@ -24,7 +25,11 @@ def _setup_op(test_context: TestContext) -> LostVoidRunLevel:
     """构造一个 ENTRY 类型的 LostVoidRunLevel 实例,前置加载武备/挑战配置。"""
     test_context.lost_void.load_artifact_data()
     test_context.lost_void.load_challenge_config()
-    return LostVoidRunLevel(test_context, LostVoidRegionType.ENTRY)
+    return LostVoidRunLevel(
+        test_context,
+        LostVoidRegionType.ENTRY,
+        LostVoidLevelInteractionState(),
+    )
 
 
 # 非战斗类区域:status 恒为「非战斗区域」(不依赖标志位)
@@ -110,5 +115,9 @@ def test_boss_default_pre_battle_is_true(test_context: TestContext) -> None:
     """BOSS 实例化时 boss_pre_battle 默认 True(source: region_type == BOSS)。"""
     test_context.lost_void.load_artifact_data()
     test_context.lost_void.load_challenge_config()
-    op = LostVoidRunLevel(test_context, LostVoidRegionType.BOSS)
+    op = LostVoidRunLevel(
+        test_context,
+        LostVoidRegionType.BOSS,
+        LostVoidLevelInteractionState(),
+    )
     assert op.boss_pre_battle is True

--- a/test/zzz_od/application/hollow_zero/lost_void/test_run_level_repeat_interact.py
+++ b/test/zzz_od/application/hollow_zero/lost_void/test_run_level_repeat_interact.py
@@ -1,0 +1,52 @@
+"""LostVoidRunLevel 重复交互对象处理测试。"""
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from test.conftest import TestContext
+
+import zzz_od.application.hollow_zero.lost_void.operation.lost_void_run_level as run_level_module
+from zzz_od.application.hollow_zero.lost_void.lost_void_challenge_config import (
+    LostVoidRegionType,
+)
+from zzz_od.application.hollow_zero.lost_void.operation.interact.lost_void_interact_target_const import (
+    LostVoidInteractNPC,
+    LostVoidInteractTarget,
+)
+from zzz_od.application.hollow_zero.lost_void.operation.lost_void_run_level import (
+    LostVoidLevelInteractionState,
+    LostVoidRunLevel,
+)
+
+
+def test_repeat_interact_moves_away_before_returning_to_detection(
+    test_context: TestContext,
+) -> None:
+    """已完成的对象会先复用交互后移动逻辑离开，再返回非战斗识别。"""
+    op = LostVoidRunLevel(
+        test_context,
+        LostVoidRegionType.FRIENDLY_TALK,
+        LostVoidLevelInteractionState(),
+    )
+    op.last_screenshot = None
+    target = LostVoidInteractTarget(
+        name=LostVoidInteractNPC.MA_LIN.value,
+        icon='感叹号',
+        is_npc=True,
+    )
+    op.level_interaction_state.mark_completed(op.get_interact_target_key(target))
+
+    with (patch.object(op, 'round_by_find_area', return_value=op.round_success()),
+          patch.object(op, 'screenshot'),
+          patch.object(op.ctx.screen_loader, 'get_area', return_value=SimpleNamespace(rect=None)),
+          patch.object(op.ctx.ocr, 'crop_and_run_ocr', return_value={'玛琳': []}),
+          patch.object(run_level_module, 'match_interact_target', return_value=target),
+          patch.object(op, 'move_after_interact') as move_after_interact,
+          patch.object(op.ctx.controller, 'interact') as interact,
+          patch.object(run_level_module.time, 'sleep')):
+        result = op.try_interact()
+
+    assert not result.is_success
+    assert result.status == '重复交互对象'
+    assert op.interact_target is target
+    move_after_interact.assert_called_once_with()
+    interact.assert_not_called()


### PR DESCRIPTION
## 背景

配套主仓的玛琳交互过滤修复。需要保证玛琳交互完成后，YOLO 不再返回 `0007-偶遇事件`；普通重新进入层间移动不清空该状态，只有进入下一层才重置。

## 变更

- 新增玛琳交互后的偶遇事件过滤回归测试，直接验证 `detect_to_go()` 实际下发的 YOLO 标签。
- 覆盖普通 `非战斗区域` 返回后继续过滤，以及 `进入下层` 后恢复检测两条状态边界。
- 同步调整迷失之地运行层操作构造参数和入口过滤登记测试。
- 优先级追加测试改用内存配置，避免写入本地 YAML 配置。

## 验证

- `PYTHONPATH=src uv run pytest zzz-od-test/test/zzz_od/application/hollow_zero/lost_void/test_ma_lin_encounter_filter.py zzz-od-test/test/zzz_od/application/hollow_zero/lost_void/test_handle_interact_route.py zzz-od-test/test/zzz_od/application/hollow_zero/lost_void/test_run_level_init_region_type.py zzz-od-test/test/zzz_od/application/hollow_zero/lost_void/test_run_level_append_priority.py`
  - 32 passed
- `uv run ruff check` 通过
- `git diff --check` 通过

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **测试改进**
  * 优化交互路由测试，验证不同屏幕状态下的操作分发、状态传递及结果处理。
  * 新增玛琳完成后的偶遇事件入口过滤测试，确认进入下一层后入口可恢复。
  * 完善区域初始化、战斗优先级与放弃保护规则的测试覆盖。
  * 改进测试隔离机制，避免配置状态在测试之间相互影响。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->