### PR TITLE
test: 覆盖滚轮滚动

### DIFF
--- a/test/one_dragon/base/controller/pc_controller_base/test_win_scroll.py
+++ b/test/one_dragon/base/controller/pc_controller_base/test_win_scroll.py
@@ -1,0 +1,24 @@
+import pytest
+
+from one_dragon.base.controller import pc_controller_base
+from one_dragon.base.geometry.point import Point
+
+
+def test_win_scroll_uses_raw_wheel_clicks(monkeypatch: pytest.MonkeyPatch) -> None:
+    move_calls: list[tuple[int, int]] = []
+    scroll_calls: list[tuple[int, int, int]] = []
+    monkeypatch.setattr(
+        pc_controller_base.pyautogui,
+        'moveTo',
+        lambda x, y: move_calls.append((x, y)),
+    )
+    monkeypatch.setattr(
+        pc_controller_base.pyautogui,
+        'scroll',
+        lambda clicks, x, y: scroll_calls.append((clicks, x, y)),
+    )
+
+    pc_controller_base.win_scroll(300, Point(100, 200))
+
+    assert move_calls == [(100, 200)]
+    assert scroll_calls == [(-300, 100, 200)]

--- a/test/one_dragon/base/screen/screen_utils/test_scroll_area.py
+++ b/test/one_dragon/base/screen/screen_utils/test_scroll_area.py
@@ -1,0 +1,30 @@
+from types import SimpleNamespace
+
+from one_dragon.base.geometry.point import Point
+from one_dragon.base.geometry.rectangle import Rect
+from one_dragon.base.screen import screen_utils
+from one_dragon.base.screen.screen_area import ScreenArea
+
+
+class ScrollRecorder:
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[int, int, int]] = []
+
+    def scroll(self, down: int, pos: Point | None = None) -> None:
+        assert pos is not None
+        self.calls.append((down, pos.x, pos.y))
+
+
+def test_scroll_area_uses_wheel_direction_and_area_center() -> None:
+    controller = ScrollRecorder()
+    ctx = SimpleNamespace(controller=controller)
+    area = ScreenArea(pc_rect=Rect(100, 200, 500, 600))
+
+    screen_utils.scroll_area(ctx, area)
+    screen_utils.scroll_area(ctx, area, direction='up')
+
+    assert controller.calls == [
+        (300, 300, 400),
+        (-300, 300, 400),
+    ]


### PR DESCRIPTION
## 变更
- 覆盖 `screen_utils.scroll_area` 的滚轮方向和区域中心位置。
- 覆盖 `win_scroll` 直接传递滚轮步数。

## 验证
- `uv run pytest zzz-od-test/zzz-od-test-scroll/test/one_dragon/base/screen/screen_utils/test_scroll_area.py zzz-od-test/zzz-od-test-scroll/test/one_dragon/base/controller/pc_controller_base/test_win_scroll.py`

配套主仓滚轮滚动改动。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **测试**
  * 新增滚动功能测试，验证鼠标滚轮方向及滚动参数传递正确。
  * 新增滚动区域测试，确认滚动位置使用区域中心点，并支持上下滚动方向切换。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->