### PR TITLE
test(auto_battle): 普攻兜底 gate 配套测试

### DIFF
--- a/test/zzz_od/auto_battle/test_auto_battle_fallback_guard.py
+++ b/test/zzz_od/auto_battle/test_auto_battle_fallback_guard.py
@@ -1,0 +1,172 @@
+"""自动战斗配置"非战斗兜底"回归守卫。
+
+针对「全配队通用」(所有配队的默认回退模板,auto_battle_operator.FALLBACK_TEMPLATE_NAME),
+检查其中是否存在「未被战内信号守住」的兜底操作 —— 即战斗结束后(战内状态失配、
+流程落到兜底分支)仍会触发的操作。这类操作若是攻击类(普攻 / 特殊技 / 终结技等),
+会在结算页误触与该键共用的按钮(#2157:普攻 X 与"再来一次"共用 X)。
+
+战内信号(剪枝集):祖先 states(含 scene 的 triggers)含【正向,非 `!` 否定】的
+这些前缀 → 视为"在战斗画面才为真"→ 该 operation 不会战后触发 → 安全:
+  - `[前台-/后台-/后台-1-/后台-2-…]`:前台/后台任意状态(角色 / 能量 / 血量扣减 / 类型 等),
+    3 人队识别到任意位置的任意战内 UI = 在战斗画面
+  - `[按键可用-…]`:任意按钮可用(终结技/特殊攻击/快速支援/切换后援/普通攻击/连携技 等)
+  - `[连携技-…]`:连携技画面状态;`[闪避识别-…]`:闪避识别(黄光等)
+  - `[自定义-…]`:战内自定义事件(连携跳过/失衡时间/黄光切人/快速支援换人 等,战中才设)
+  - `[<角色>-…]`:角色专属状态(如 `[苍角-能量]`)
+  - scene 的 `triggers`:scene 只在 trigger 触发时活跃,trigger 是上面任一战内信号时,
+    整个 scene 的 handler 都受其约束(作顶层祖先参与剪枝)
+
+加载用 `AutoBattleOperator.init()`(走真实 loader,展开所有 state_template /
+operation_template),再遍历展开后的 Scene → StateHandler 树,收集每个叶子 operation
+的祖先 states 链。比手写递归复刻 loader 更可靠(展开逻辑直接复用框架)。
+"""
+from __future__ import annotations
+
+import re
+from collections.abc import Callable
+from pathlib import Path
+
+from test.conftest import TestContext
+
+from one_dragon.base.conditional_operation.state_handler import StateHandler
+from zzz_od.auto_battle.auto_battle_operator import AutoBattleOperator
+
+# 受检入口配置:全配队通用(默认回退模板,覆盖面最广)
+_ENTRY = '全配队通用'
+
+# 前台/后台任意位置的任意状态(角色 / 能量 / 血量扣减 / 类型 等)→ 在战斗画面
+_POSITIONS = ['前台-', '后台-', '后台-1-', '后台-2-']
+# 速切模板里非角色(通用)模板,不算角色名
+_NON_CHAR_TEMPLATES = {'速切模板-全角色', '速切模板-通用', '速切模板-强攻站场'}
+# 战内信号前缀:祖先 states 含这些前缀的【正向】状态 → 在战斗画面为真
+#   按键可用-  :任意按钮可用(终结技/特殊攻击/快速支援/切换后援/普通攻击/连携技 等)
+#   连携技-    :连携技画面(连携技-1-<角色> / 连携技-2-<角色> / 连携技-准备)
+#   闪避识别-  :闪避识别(黄光等)
+#   自定义-    :战内自定义事件(连携跳过/失衡时间/黄光切人/快速支援换人/锁定丢失 等,
+#               均由 auto_op 在战斗中"设置状态"写入,非战斗不发生)
+_IN_BATTLE_STATE_PREFIXES = ['按键可用-', '连携技-', '闪避识别-', '自定义-']
+
+_STATE_HANDLER_DIR = Path('config') / 'auto_battle_state_handler'
+
+
+def _agent_names() -> list[str]:
+    """从 `速切模板-*.sample.yml` 文件名推导角色名(排除非角色通用模板)。"""
+    names: list[str] = []
+    for p in _STATE_HANDLER_DIR.glob('速切模板-*.sample.yml'):
+        name = p.name.replace('速切模板-', '').replace('.sample.yml', '')
+        if name not in _NON_CHAR_TEMPLATES:
+            names.append(name)
+    return names
+
+
+def _prune_members() -> tuple[list[str], list[str]]:
+    """返回 (精确剪枝成员, 前缀剪枝成员),合起来代表"在战斗画面才为真"的战内信号。
+
+    祖先 states(含 scene triggers)含【正向,非 !】的任一即视为战内安全。
+    全部用前缀匹配:前台/后台任意状态、角色专属、各类战内信号前缀。
+    """
+    names = _agent_names()
+    exact: list[str] = []
+    prefix = (
+        _POSITIONS  # 前台-/后台-…:任意位置任意状态(角色/能量/血量扣减/类型…)= 在战斗画面
+        + [f'{n}-' for n in names]  # [角色-…]:角色专属状态(如 [苍角-能量])
+        + _IN_BATTLE_STATE_PREFIXES  # 按键可用-/连携技-/闪避识别-/自定义-
+    )
+    return exact, prefix
+
+
+def _is_pruned(ancestor_states: list[str], exact: list[str], prefix: list[str]) -> bool:
+    """任一祖先 states 含【正向(未 `!` 否定)】剪枝成员 → 视为战内安全。"""
+    for s in ancestor_states:
+        if not s:
+            continue
+        for m in exact:
+            # [成员] 或 [成员, …],且前方无 ! 否定
+            if re.search(rf'(?<!!)\[{re.escape(m)}(?=[\],])', s):
+                return True
+        for m in prefix:
+            if re.search(rf'(?<!!)\[{re.escape(m)}', s):
+                return True
+    return False
+
+
+def _walk(handler: StateHandler, ancestor_states: list[str], results: list[dict]) -> None:
+    """递归遍历展开后的 StateHandler 树,收集叶子 operation + 祖先 states 链。"""
+    states: str = handler.states
+    sub_handlers = handler.sub_handlers
+    operations = handler.operations
+    if sub_handlers:
+        anc = ancestor_states + [states]
+        for sub in sub_handlers:
+            _walk(sub, anc, results)
+    elif operations:
+        anc = ancestor_states + [states]
+        for op_def in operations:
+            results.append({
+                'op_name': op_def.op_name or '',
+                'ancestor_states': anc,
+                'parent_states': states,
+            })
+
+
+def _collect_ungated(
+    test_context: TestContext,
+    op_filter: Callable[[str], bool],
+) -> list[dict]:
+    """加载全配队通用,返回「未 gated(非战内)的兜底 operation」列表。
+
+    Args:
+        test_context: 测试 fixture(提供 auto_battle_context)
+        op_filter: 操作名过滤(如只看普攻,或看全部)
+
+    Returns:
+        未被战内信号守住的兜底 operation 列表,每项含 op_name / parent_states / ancestor_states
+    """
+    op = AutoBattleOperator(test_context.auto_battle_context, 'auto_battle', _ENTRY)
+    op.init()
+    exact, prefix = _prune_members()
+    all_ops: list[dict] = []
+    for scene in op.scenes:
+        # scene 的 triggers 也是战内信号来源:scene 只在这些状态触发时才活跃,
+        # trigger 若是战内(如 按键可用-X)则整个 scene 的 handler 都受其约束。
+        # 包成 [trigger] 放进祖先链,让剪枝正则按战内信号匹配。
+        triggers = [f'[{t}]' for t in scene.triggers]
+        for handler in scene.handlers:
+            _walk(handler, triggers, all_ops)
+    return [
+        r for r in all_ops
+        if op_filter(r['op_name']) and not _is_pruned(r['ancestor_states'], exact, prefix)
+    ]
+
+
+class TestAutoBattleFallbackGuard:
+
+    def test_no_ungated_normal_attack_fallback(self, test_context: TestContext) -> None:
+        """普攻兜底必须被战内信号守住:未 gated 的普攻兜底应为 0(否则战后残留普攻,#2157)。"""
+
+        def is_normal_attack(op_name: str) -> bool:
+            return '普通攻击' in op_name and not op_name.endswith('松开')
+
+        candidates = _collect_ungated(test_context, is_normal_attack)
+        assert candidates == [], (
+            '存在未被战内信号守住的普攻兜底(战后会残留发普攻,#2157):\n'
+            + '\n'.join(
+                f"  op={c['op_name']!r} parent_states={c['parent_states']!r}" for c in candidates
+            )
+        )
+
+    def test_no_ungated_fallback_in_combat(self, test_context: TestContext) -> None:
+        """所有兜底操作(不限普攻)都必须被战内信号守住:未 gated 兜底应为 0。
+
+        比 test_no_ungated_normal_attack_fallback 更严格,覆盖按键-连携技 / 终结技 /
+        特殊攻击 / 切换后援等所有操作类型 —— 任何战后会触发的兜底都可能误触结算页
+        按钮(#2157 类)。当前剪枝集(战内信号前缀 + scene triggers)已覆盖全部战内
+        信号,全配队通用里所有兜底都被某个战内信号守住,故应为 0。
+        """
+        candidates = _collect_ungated(test_context, lambda _: True)
+        assert candidates == [], (
+            '存在未被战内信号守住的兜底操作(战后会触发):\n'
+            + '\n'.join(
+                f"  op={c['op_name']!r} ancestors={c['ancestor_states']}" for c in candidates
+            )
+        )

--- a/test/zzz_od/auto_battle/test_normal_attack_ready_state.py
+++ b/test/zzz_od/auto_battle/test_normal_attack_ready_state.py
@@ -1,7 +1,7 @@
 """按键可用-普通攻击 状态写入测试。
 
 验证 check_battle_state 在普攻按钮可用(in_battle=True)时写入该状态,
-按钮缺失(in_battle=False)时不更新(只写 True 模式,不 is_clear)。
+按钮缺失(in_battle=False)时清除状态(is_clear=True)。
 
 check_battle_state 内部会往线程池提交 dodge/agent/target/quick/switch_backup/chain
 等子任务,它们依赖完整 ctx 与模型;本测试 patch 掉这些子任务,聚焦"状态是否写入"
@@ -60,8 +60,8 @@ def test_normal_attack_ready_state_recorded_when_in_battle() -> None:
     assert recorder.last_record_time == 100.0
 
 
-def test_normal_attack_ready_state_not_updated_when_button_missing() -> None:
-    """in_battle=False 不更新(只写 True):True@100 后 False@200,last_record_time 仍==100。"""
+def test_normal_attack_ready_state_cleared_when_button_missing() -> None:
+    """in_battle=False 清除状态:True@100 后 False@200,last_record_time 被清成 0。"""
     abc = _make_auto_battle_context()
     screen = np.zeros((1080, 1920, 3), dtype=np.uint8)
     patches = _patch_sub_checks(abc)
@@ -78,4 +78,4 @@ def test_normal_attack_ready_state_not_updated_when_button_missing() -> None:
     recorder = abc.state_record_service.get_state_recorder(
         BattleStateEnum.STATUS_NORMAL_ATTACK_READY.value)
     assert recorder is not None
-    assert recorder.last_record_time == 100.0  # 未被 False@200 覆盖
+    assert recorder.last_record_time == 0  # False@200 is_clear 清成 0

--- a/test/zzz_od/auto_battle/test_normal_attack_ready_state.py
+++ b/test/zzz_od/auto_battle/test_normal_attack_ready_state.py
@@ -1,0 +1,81 @@
+"""按键可用-普通攻击 状态写入测试。
+
+验证 check_battle_state 在普攻按钮可用(in_battle=True)时写入该状态,
+按钮缺失(in_battle=False)时不更新(只写 True 模式,不 is_clear)。
+
+check_battle_state 内部会往线程池提交 dodge/agent/target/quick/switch_backup/chain
+等子任务,它们依赖完整 ctx 与模型;本测试 patch 掉这些子任务,聚焦"状态是否写入"
+这一同步行为(is_normal_attack_btn_available 也 patch 以控制 in_battle)。
+"""
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+
+from zzz_od.auto_battle.auto_battle_context import AutoBattleContext
+from zzz_od.auto_battle.auto_battle_state import BattleStateEnum
+
+
+def _make_ctx() -> MagicMock:
+    """mock ctx(AutoBattleContext.__init__ 只读取属性,MagicMock 足够)。"""
+    ctx = MagicMock()
+    ctx.project_config.screen_standard_width = 1920
+    return ctx
+
+
+def _make_auto_battle_context() -> AutoBattleContext:
+    abc = AutoBattleContext(_make_ctx())
+    # 屏蔽提交到线程池的子任务(依赖完整 ctx/模型),使测试聚焦状态写入
+    abc.dodge_context = MagicMock()
+    abc.agent_context = MagicMock()
+    abc.target_context = MagicMock()
+    return abc
+
+
+def _patch_sub_checks(abc: AutoBattleContext):
+    """patch 掉 check_battle_state 直接调用的本类方法(check_quick_assist 等)。"""
+    return [
+        patch.object(abc, 'check_quick_assist'),
+        patch.object(abc, 'check_switch_backup'),
+        patch.object(abc, 'check_chain_attack'),
+    ]
+
+
+def test_normal_attack_ready_state_recorded_when_in_battle() -> None:
+    """in_battle=True → 写入 按键可用-普通攻击,last_record_time == screenshot_time。"""
+    abc = _make_auto_battle_context()
+    screen = np.zeros((1080, 1920, 3), dtype=np.uint8)
+    patches = _patch_sub_checks(abc)
+    for p in patches:
+        p.start()
+    try:
+        with patch.object(abc, 'is_normal_attack_btn_available', return_value=True):
+            abc.check_battle_state(screen, screenshot_time=100.0)
+    finally:
+        for p in patches:
+            p.stop()
+
+    recorder = abc.state_record_service.get_state_recorder(
+        BattleStateEnum.STATUS_NORMAL_ATTACK_READY.value)
+    assert recorder is not None
+    assert recorder.last_record_time == 100.0
+
+
+def test_normal_attack_ready_state_not_updated_when_button_missing() -> None:
+    """in_battle=False 不更新(只写 True):True@100 后 False@200,last_record_time 仍==100。"""
+    abc = _make_auto_battle_context()
+    screen = np.zeros((1080, 1920, 3), dtype=np.uint8)
+    patches = _patch_sub_checks(abc)
+    for p in patches:
+        p.start()
+    try:
+        with patch.object(abc, 'is_normal_attack_btn_available', side_effect=[True, False]):
+            abc.check_battle_state(screen, screenshot_time=100.0)
+            abc.check_battle_state(screen, screenshot_time=200.0)
+    finally:
+        for p in patches:
+            p.stop()
+
+    recorder = abc.state_record_service.get_state_recorder(
+        BattleStateEnum.STATUS_NORMAL_ATTACK_READY.value)
+    assert recorder is not None
+    assert recorder.last_record_time == 100.0  # 未被 False@200 覆盖


### PR DESCRIPTION
## 说明

#2585 主仓配套测试。按跨仓合并顺序,**测试仓先合 → 主仓 #2585 再合**(确保主仓 main 的 test-check clone 测试仓 main 时有这些测试)。

## 包含
- `test_normal_attack_ready_state.py`:`按键可用-普通攻击` 状态写入测试(`check_battle_state` in_battle 写入 / 按钮缺失 is_clear 清除)
- `test_auto_battle_fallback_guard.py`:非战斗兜底回归守卫(全配队通用里未被战内信号守住的普攻/兜底操作应为 0,#2157 防回归)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **测试**
  * 新增自动战斗兜底回归测试，确保战斗外不会误触发攻击或其他操作。
  * 新增普通攻击按键状态测试，验证按键可用时正确记录状态，不可用时及时清除状态。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->