### PR TITLE
test: 放宽角色状态模板图片断言

### DIFF
--- a/test/zzz_od/game_data/agent/test_agent_template_exist.py
+++ b/test/zzz_od/game_data/agent/test_agent_template_exist.py
@@ -1,28 +1,16 @@
 from test.conftest import TestContext
 
+from one_dragon.base.screen.template_info import TemplateInfo
 from zzz_od.game_data.agent import (
     AgentEnum,
     AgentStateCheckWay,
     AgentStateDef,
     CommonAgentStateEnum,
 )
-from one_dragon.base.screen.template_info import TemplateInfo
 
-# check_way → 该状态识别实际依赖的资产(见 agent_state_checker 各 check 方法):
-#   - LENGTH 类:只裁 rect 算长度,依赖 config 的 point_list 坐标,不靠 raw/mask;
-#   - COLOR_RANGE / COLOR_CHANNEL 类:bitwise_and(mask),依赖 mask.png;
-#   - TEMPLATE_* 类:match_template,依赖 raw.png + mask.png。
-_LENGTH_WAYS = {
-    AgentStateCheckWay.BACKGROUND_GRAY_RANGE_LENGTH,
-    AgentStateCheckWay.FOREGROUND_COLOR_RANGE_LENGTH,
-    AgentStateCheckWay.FOREGROUND_GRAY_RANGE_LENGTH,
-}
-_MASK_WAYS = {
-    AgentStateCheckWay.COLOR_RANGE_CONNECT,
-    AgentStateCheckWay.COLOR_RANGE_EXIST,
-    AgentStateCheckWay.COLOR_CHANNEL_MAX_RANGE_EXIST,
-    AgentStateCheckWay.COLOR_CHANNEL_EQUAL_RANGE_CONNECT,
-}
+# 所有角色状态检测均根据 config 的 point_list 裁取检测区域。
+# COLOR_RANGE / COLOR_CHANNEL 类在没有 mask.png 时检测整个裁取区域；
+# TEMPLATE_* 类再将 raw.png 用作匹配模板，mask.png 仅用于限制匹配范围。
 _RAW_WAYS = {
     AgentStateCheckWay.TEMPLATE_FOUND,
     AgentStateCheckWay.TEMPLATE_NOT_FOUND,
@@ -38,21 +26,18 @@ def _state_template_err(state_def: AgentStateDef, template: TemplateInfo | None)
     if template is None:
         return None
     way = state_def.check_way
-    if way in _LENGTH_WAYS:
-        return None if template.point_list else '缺 point_list 坐标(LENGTH 类需 config 坐标)'
-    if way in _MASK_WAYS:
-        return None if template.mask is not None else '缺 mask.png(MASK 类)'
-    if way in _RAW_WAYS:
-        if template.raw is None:
-            return '缺 raw.png(TEMPLATE 类)'
-        if template.mask is None:
-            return '缺 mask.png(TEMPLATE 类)'
+    if not template.point_list:
+        return '缺 point_list 坐标(状态检测需 config 坐标)'
+    if way in _RAW_WAYS and template.raw is None:
+        return '缺 raw.png(TEMPLATE 类需原图)'
     return None
 
 
 class TestAgentTemplateExist:
-    """代理人模板完整性:遍历 ``AgentEnum`` / ``CommonAgentStateEnum`` 引用的模板,按 ``check_way``
-    断言所需资产齐全(LENGTH→坐标 / MASK→mask / TEMPLATE→raw+mask);预定不检测的 pos(目录缺)跳过。"""
+    """代理人模板完整性:遍历 ``AgentEnum`` / ``CommonAgentStateEnum`` 引用的模板。
+
+    所有状态模板都需要坐标；模板匹配状态还需要原图。mask.png 是可选的检测范围限制。
+    """
 
     def test_battle_avatar(self, test_context: TestContext):
         """战斗头像:每个 Agent × 每个皮肤 × 前台/后台(``avatar_1_`` / ``avatar_2_``),raw 必须可读。"""


### PR DESCRIPTION
## 变更

- 所有角色状态模板统一校验 `config.yml` 的 `point_list`，它是运行时裁取检测区域的最低依赖。
- `COLOR_RANGE`、`COLOR_CHANNEL` 与长度检测不再强制要求 `mask.png`；未提供掩码时按完整裁取区域检测。
- `TEMPLATE_FOUND`、`TEMPLATE_NOT_FOUND` 仍要求 `raw.png`，但 `mask.png` 保持可选。

## 原因

主仓 `97ef05be` 已放宽模板加载，允许仅含 `config.yml` 的坐标模板。蕾米埃尔虚曜 `remielle_voidflare_*` 正是这种模板，当前测试却把它误判为缺少 `mask.png`，导致主仓 #2599 的 CI 失败。

强制给坐标检测模板附加无运行用途的图片会增加资源包更新下载量；测试应验证实际运行所需的最低资产。

## 验证

- `uv run pytest zzz-od-test/zzz-od-test-template-assets/test/zzz_od/game_data/agent/test_agent_template_exist.py`
- `uv run ruff check zzz-od-test/zzz-od-test-template-assets/test/zzz_od/game_data/agent/test_agent_template_exist.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug 修复**
  - 优化模板资产完整性校验，减少不必要的报错。
  - 模板匹配状态现在仅要求配置检测区域及必要的原始模板图片。
  - 遮罩图片调整为可选项，仅用于限制检测范围；缺少遮罩时仍可执行相关区域检测。

- **文档**
  - 更新模板资产校验规则说明，使其与实际检测行为保持一致。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->