### PR TITLE
test(envs): 覆盖 Git 同步回退与用户状态

### DIFF
--- a/test/one_dragon/envs/test_git_service.py
+++ b/test/one_dragon/envs/test_git_service.py
@@ -12,6 +12,8 @@ import one_dragon.envs.git_service as git_service_module
 from one_dragon.envs.env_config import EnvConfig, ProxyTypeEnum
 from one_dragon.envs.git_service import (
     GitService,
+    GitSyncStatus,
+    _cleanup_stale_fetch_repositories,
     _configure_alternate_objects,
     _fetch_remote_worker,
     _FetchProgressRemoteCallbacks,
@@ -104,6 +106,67 @@ def test_remove_temp_repo_handles_readonly_pack_files(tmp_path: Path) -> None:
     _remove_temp_repo(str(temp_repo_dir))
 
     assert not temp_repo_dir.exists()
+
+
+def test_remove_temp_repo_defers_windows_busy_pack(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    error = PermissionError('busy')
+    error.winerror = 32
+    info_messages: list[str] = []
+    warning_messages: list[str] = []
+    monkeypatch.setattr(git_service_module.sys, 'platform', 'win32')
+    monkeypatch.setattr(git_service_module.shutil, 'rmtree', lambda *args, **kwargs: (_ for _ in ()).throw(error))
+    monkeypatch.setattr(git_service_module.log, 'info', info_messages.append)
+    monkeypatch.setattr(
+        git_service_module.log,
+        'warning',
+        lambda message, **kwargs: warning_messages.append(message),
+    )
+
+    _remove_temp_repo('fetch_busy')
+
+    assert info_messages == ['Git fetch 临时仓库仍被占用，将在下次启动时清理: fetch_busy']
+    assert warning_messages == []
+
+
+def test_cleanup_stale_fetch_repositories_removes_dead_and_legacy_directories(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    dead_repo = tmp_path / 'fetch_123_dead'
+    active_repo = tmp_path / 'fetch_456_active'
+    legacy_repo = tmp_path / 'fetch_old'
+    unrelated_dir = tmp_path / 'keep'
+    for directory in (dead_repo, active_repo, legacy_repo, unrelated_dir):
+        directory.mkdir()
+    monkeypatch.setattr(git_service_module, '_is_process_running', lambda process_id: process_id == 456)
+
+    _cleanup_stale_fetch_repositories(tmp_path)
+
+    assert not dead_repo.exists()
+    assert active_repo.exists()
+    assert not legacy_repo.exists()
+    assert unrelated_dir.exists()
+
+
+def test_cleanup_stale_fetch_repositories_runs_once_per_process_root(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    cleanup_calls: list[Path] = []
+    resolved_root = tmp_path.resolve()
+    git_service_module._fetch_temp_cleanup_roots.discard(resolved_root)
+    monkeypatch.setattr(
+        git_service_module,
+        '_cleanup_stale_fetch_repositories',
+        cleanup_calls.append,
+    )
+
+    git_service_module._cleanup_stale_fetch_repositories_once(tmp_path)
+    git_service_module._cleanup_stale_fetch_repositories_once(tmp_path)
+
+    assert cleanup_calls == [resolved_root]
 
 
 def test_repository_objects_path_handles_linked_worktree(tmp_path: Path) -> None:
@@ -490,6 +553,7 @@ class TestFetchProgressRemoteCallbacks:
         self,
         git_service: GitService,
         monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
     ) -> None:
         repo = SimpleNamespace(references={})
         events: list[tuple[float, str]] = []
@@ -501,6 +565,11 @@ class TestFetchProgressRemoteCallbacks:
             message_callback({'type': 'result', 'success': True})
 
         monkeypatch.setattr(git_service_module, '_fetch_remote_worker', fake_worker)
+        monkeypatch.setattr(
+            git_service_module.os_utils,
+            'get_path_under_work_dir',
+            lambda *sub_paths: str(tmp_path.joinpath(*sub_paths)),
+        )
         monkeypatch.setattr(git_service, '_open_repo', lambda: repo)
         monkeypatch.setattr(
             git_service,
@@ -516,6 +585,7 @@ class TestFetchProgressRemoteCallbacks:
         )
 
         assert imported
+        assert Path(imported[0]).name.startswith(f'fetch_{git_service_module.os.getpid()}_')
         assert events[0][0] == pytest.approx(0.3)
         assert events[0][1] == '拉取对象 2/4 (50%)'
 
@@ -838,6 +908,16 @@ class TestFetchProgressRemoteCallbacks:
         assert git_service.env_config.last_repository_url == CNB_REPOSITORY.url
         assert restored is True
 
+    def test_successful_fetch_still_fails_when_origin_restore_fails(
+        self,
+        git_service: GitService,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(git_service, '_fetch_remote_once', lambda *args: None)
+        monkeypatch.setattr(git_service, '_restore_origin', lambda: False)
+
+        assert git_service._fetch_remote() is False
+
     def test_auto_source_records_successful_repository_when_manifest_rejects_update(
         self,
         git_service: GitService,
@@ -865,12 +945,42 @@ class TestFetchProgressRemoteCallbacks:
             lambda: (False, '目标版本的运行环境与当前不兼容'),
         )
 
-        success, message = git_service._fetch_and_checkout_latest_branch()
+        status, message = git_service._fetch_and_checkout_latest_branch()
 
-        assert success is False
+        assert status is GitSyncStatus.RUNTIME_INCOMPATIBLE
         assert message == '目标版本的运行环境与当前不兼容'
         assert attempted_urls == [GITHUB_REPOSITORY.url, CNB_REPOSITORY.url]
         assert git_service.env_config.last_repository_url == CNB_REPOSITORY.url
+
+    def test_first_clone_returns_runtime_incompatible_before_checkout(
+        self,
+        git_service: GitService,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        calls: list[str] = []
+        monkeypatch.setattr(git_service_module, 'init_repository', lambda path: calls.append('init'))
+        monkeypatch.setattr(
+            git_service,
+            '_fetch_remote',
+            lambda progress_callback, stage_start, stage_end: calls.append('fetch') is None,
+        )
+        monkeypatch.setattr(
+            git_service,
+            '_check_remote_manifest_compatible',
+            lambda: (False, '目标版本的运行环境与当前不兼容'),
+        )
+        monkeypatch.setattr(git_service, '_checkout_branch', lambda: calls.append('checkout') is None)
+        monkeypatch.setattr(
+            git_service,
+            '_sync_with_remote',
+            lambda force: (calls.append('sync') is None, ''),
+        )
+
+        status, message = git_service._clone_repository()
+
+        assert status is GitSyncStatus.RUNTIME_INCOMPATIBLE
+        assert message == '目标版本的运行环境与当前不兼容'
+        assert calls == ['init', 'fetch']
 
     def test_fetch_remote_returns_false_when_all_sources_fail(
         self,
@@ -984,7 +1094,28 @@ class TestFetchProgressRemoteCallbacks:
         assert git_service._fetch_remote() is True
         assert rebuild_calls == [None]
 
-    def test_mixed_failures_do_not_trigger_repository_rebuild(
+    def test_missing_object_failure_rebuilds_when_origin_restore_fails(
+        self,
+        git_service: GitService,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        rebuild_calls: list[object] = []
+        monkeypatch.setattr(
+            git_service,
+            '_fetch_remote_once',
+            lambda *args: (_ for _ in ()).throw(KeyError('object not found - no match for id')),
+        )
+        monkeypatch.setattr(git_service, '_restore_origin', lambda: False)
+        monkeypatch.setattr(
+            git_service,
+            '_rebuild_repository',
+            lambda progress_callback: rebuild_calls.append(progress_callback) is None,
+        )
+
+        assert git_service._fetch_remote() is True
+        assert rebuild_calls == [None]
+
+    def test_missing_object_and_network_failure_trigger_repository_rebuild(
         self,
         git_service: GitService,
         monkeypatch: pytest.MonkeyPatch,
@@ -1007,8 +1138,56 @@ class TestFetchProgressRemoteCallbacks:
             lambda progress_callback: rebuild_calls.append(progress_callback) is None,
         )
 
+        assert git_service._fetch_remote() is True
+        assert rebuild_calls == [None]
+
+    def test_network_failures_do_not_trigger_repository_rebuild(
+        self,
+        git_service: GitService,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        rebuild_calls: list[object] = []
+        monkeypatch.setattr(
+            git_service,
+            '_fetch_remote_once',
+            lambda *args: (_ for _ in ()).throw(RuntimeError('request failed')),
+        )
+        monkeypatch.setattr(git_service, '_restore_origin', lambda: True)
+        monkeypatch.setattr(
+            git_service,
+            '_rebuild_repository',
+            lambda progress_callback: rebuild_calls.append(progress_callback) is None,
+        )
+
         assert git_service._fetch_remote() is False
         assert rebuild_calls == []
+
+    def test_rebuild_repository_skips_repository_with_extra_remote(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        repo_path = tmp_path / 'repo'
+        repo = pygit2.init_repository(str(repo_path))
+        repo.remotes.create('origin', 'https://origin.example/repo.git')
+        repo.remotes.create('upstream', 'https://upstream.example/repo.git')
+        git_service = GitService(
+            SimpleNamespace(),
+            SimpleNamespace(),
+            create_repo_config(),
+            repo_dir=str(repo_path),
+        )
+        clone_calls: list[object] = []
+        monkeypatch.setattr(
+            git_service,
+            '_clone_repository',
+            lambda progress_callback: clone_calls.append(progress_callback),
+        )
+
+        assert git_service._rebuild_repository(None) is False
+        assert clone_calls == []
+        assert (repo_path / '.git').is_dir()
+        assert list(repo_path.glob('.git.corrupted.*')) == []
 
     def test_rebuild_repository_backs_up_git_directory(
         self,
@@ -1024,9 +1203,9 @@ class TestFetchProgressRemoteCallbacks:
             repo_dir=str(repo_path),
         )
 
-        def fake_clone(progress_callback: object) -> tuple[bool, str]:
+        def fake_clone(progress_callback: object) -> tuple[GitSyncStatus, str]:
             pygit2.init_repository(str(repo_path))
-            return True, 'ok'
+            return GitSyncStatus.SUCCESS, 'ok'
 
         monkeypatch.setattr(git_service, '_clone_repository', fake_clone)
 

--- a/test/one_dragon/envs/test_git_service.py
+++ b/test/one_dragon/envs/test_git_service.py
@@ -574,7 +574,7 @@ class TestFetchProgressRemoteCallbacks:
         monkeypatch.setattr(
             git_service,
             '_import_fetch_result',
-            lambda temp_repo_dir, progress_callback, stage_start, stage_end: imported.append(temp_repo_dir),
+            lambda temp_repo_dir, progress_callback, stage_start, stage_end, tag_name: imported.append(temp_repo_dir),
         )
 
         git_service._fetch_remote_once(
@@ -648,6 +648,64 @@ class TestFetchProgressRemoteCallbacks:
         assert remote_ref.target == commit_id
         assert list(target_repo.remotes.names()) == []
 
+    def test_import_fetch_result_uses_annotated_tag_as_remote_branch(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        source_path = tmp_path / 'source'
+        target_path = tmp_path / 'target'
+        source_repo = pygit2.init_repository(str(source_path), bare=True)
+        tree_builder = source_repo.TreeBuilder()
+        blob_id = source_repo.create_blob(b'release')
+        tree_builder.insert('README.md', blob_id, pygit2.GIT_FILEMODE_BLOB)
+        tree_id = tree_builder.write()
+        signature = pygit2.Signature('test', 'test@example.com')
+        commit_id = source_repo.create_commit(
+            'refs/heads/main',
+            signature,
+            signature,
+            'release',
+            tree_id,
+            [],
+        )
+        source_repo.create_tag(
+            'v1.0.0',
+            commit_id,
+            pygit2.enums.ObjectType.COMMIT,
+            signature,
+            'v1.0.0',
+        )
+        pygit2.init_repository(str(target_path))
+        env_config = SimpleNamespace(
+            git_branch='main',
+            git_remote='origin',
+            repository_url=GITHUB_REPOSITORY.url,
+            last_repository_url='',
+            is_gh_proxy=False,
+            gh_proxy_url='',
+            is_personal_proxy=False,
+            personal_proxy='',
+        )
+        git_service = GitService(
+            SimpleNamespace(),
+            env_config,
+            create_repo_config(),
+            repo_dir=str(target_path),
+        )
+
+        git_service._import_fetch_result(
+            str(source_path),
+            None,
+            0.0,
+            1.0,
+            'v1.0.0',
+        )
+
+        target_repo = pygit2.Repository(str(target_path))
+        assert target_repo.references['refs/remotes/origin/main'].target == commit_id
+        assert target_repo.revparse_single('refs/tags/v1.0.0').peel(pygit2.Commit).id == commit_id
+        assert 'refs/heads/main' not in target_repo.references
+
     def run_timed_fetch_worker(
         self,
         git_service: GitService,
@@ -686,6 +744,7 @@ class TestFetchProgressRemoteCallbacks:
             progress_callback: object,
             stage_start: float,
             stage_end: float,
+            tag_name: str | None,
         ) -> None:
             nonlocal imported
             imported = True
@@ -838,7 +897,7 @@ class TestFetchProgressRemoteCallbacks:
         monkeypatch.setattr(
             git_service,
             '_import_fetch_result',
-            lambda temp_repo_dir, progress_callback, stage_start, stage_end: imported.append(temp_repo_dir),
+            lambda temp_repo_dir, progress_callback, stage_start, stage_end, tag_name: imported.append(temp_repo_dir),
         )
         monkeypatch.setattr(git_service, '_restore_origin', lambda: True)
 
@@ -885,6 +944,7 @@ class TestFetchProgressRemoteCallbacks:
             progress_callback: object,
             stage_start: float,
             stage_end: float,
+            tag_name: str | None,
         ) -> None:
             attempted_urls.append(repository_url)
             if len(attempted_urls) == 1:
@@ -932,6 +992,7 @@ class TestFetchProgressRemoteCallbacks:
             progress_callback: object,
             stage_start: float,
             stage_end: float,
+            tag_name: str | None,
         ) -> None:
             attempted_urls.append(repository_url)
             if repository_url == GITHUB_REPOSITORY.url:
@@ -962,7 +1023,7 @@ class TestFetchProgressRemoteCallbacks:
         monkeypatch.setattr(
             git_service,
             '_fetch_remote',
-            lambda progress_callback, stage_start, stage_end: calls.append('fetch') is None,
+            lambda progress_callback, stage_start, stage_end, tag_name: calls.append('fetch') is None,
         )
         monkeypatch.setattr(
             git_service,
@@ -982,6 +1043,95 @@ class TestFetchProgressRemoteCallbacks:
         assert message == '目标版本的运行环境与当前不兼容'
         assert calls == ['init', 'fetch']
 
+    def test_first_clone_uses_builtin_tag_without_manifest_check(
+        self,
+        git_service: GitService,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        calls: list[object] = []
+        monkeypatch.setattr(git_service_module, 'init_repository', lambda path: calls.append('init'))
+        monkeypatch.setattr(
+            git_service,
+            '_fetch_remote',
+            lambda progress_callback, stage_start, stage_end, tag_name: calls.append(tag_name) or True,
+        )
+        monkeypatch.setattr(
+            git_service,
+            '_check_remote_manifest_compatible',
+            lambda: (_ for _ in ()).throw(AssertionError('按内置 tag 拉取不应再检查清单')),
+        )
+        monkeypatch.setattr(git_service, '_checkout_branch', lambda: calls.append('checkout') or True)
+        monkeypatch.setattr(
+            git_service,
+            '_sync_with_remote',
+            lambda force: (calls.append(('sync', force)) is None, 'ok'),
+        )
+
+        status, message = git_service._clone_repository(initial_tag='v1.0.0')
+
+        assert status is GitSyncStatus.SUCCESS
+        assert message == '克隆仓库成功'
+        assert calls == ['init', 'v1.0.0', 'checkout', ('sync', True)]
+
+    def test_first_clone_keeps_builtin_code_when_tag_is_unavailable(
+        self,
+        git_service: GitService,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        calls: list[str] = []
+        monkeypatch.setattr(git_service_module, 'init_repository', lambda path: calls.append('init'))
+        monkeypatch.setattr(
+            git_service,
+            '_fetch_remote',
+            lambda progress_callback, stage_start, stage_end, tag_name: calls.append(tag_name) or False,
+        )
+        monkeypatch.setattr(git_service, '_checkout_branch', lambda: calls.append('checkout') is not None)
+
+        status, message = git_service._clone_repository(initial_tag='v1.0.0')
+
+        assert status is GitSyncStatus.BUILTIN_TAG_UNAVAILABLE
+        assert message == '未能获取内置版本对应的代码标签 v1.0.0'
+        assert calls == ['init', 'v1.0.0']
+
+    def test_fetch_latest_code_retries_builtin_tag_while_local_branch_is_missing(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        repo_path = tmp_path / 'repo'
+        pygit2.init_repository(str(repo_path))
+        env_config = SimpleNamespace(git_branch='main')
+        git_service = GitService(
+            SimpleNamespace(),
+            env_config,
+            create_repo_config(),
+            repo_dir=str(repo_path),
+        )
+        received_tags: list[str | None] = []
+        monkeypatch.setattr(
+            git_service,
+            '_clone_repository',
+            lambda progress_callback, initial_tag: (
+                received_tags.append(initial_tag)
+                or (
+                    GitSyncStatus.BUILTIN_TAG_UNAVAILABLE,
+                    f'未能获取内置版本对应的代码标签 {initial_tag}',
+                )
+            ),
+        )
+        monkeypatch.setattr(
+            git_service,
+            '_fetch_and_checkout_latest_branch',
+            lambda progress_callback: (_ for _ in ()).throw(AssertionError('不得退化到分支更新')),
+        )
+
+        first_status, _ = git_service.fetch_latest_code(initial_tag='v1.0.0')
+        second_status, _ = git_service.fetch_latest_code(initial_tag='v1.0.0')
+
+        assert first_status is GitSyncStatus.BUILTIN_TAG_UNAVAILABLE
+        assert second_status is GitSyncStatus.BUILTIN_TAG_UNAVAILABLE
+        assert received_tags == ['v1.0.0', 'v1.0.0']
+
     def test_fetch_remote_returns_false_when_all_sources_fail(
         self,
         git_service: GitService,
@@ -992,6 +1142,7 @@ class TestFetchProgressRemoteCallbacks:
             progress_callback: object,
             stage_start: float,
             stage_end: float,
+            tag_name: str | None,
         ) -> None:
             raise TimeoutError(repository_url)
 
@@ -1065,7 +1216,9 @@ class TestFetchProgressRemoteCallbacks:
         monkeypatch.setattr(
             git_service,
             '_fetch_remote_once',
-            lambda repository_url, progress_callback, stage_start, stage_end: attempted_urls.append(repository_url),
+            lambda repository_url, progress_callback, stage_start, stage_end, tag_name: attempted_urls.append(
+                repository_url
+            ),
         )
         monkeypatch.setattr(git_service, '_restore_origin', lambda: True)
 
@@ -1088,11 +1241,33 @@ class TestFetchProgressRemoteCallbacks:
         monkeypatch.setattr(
             git_service,
             '_rebuild_repository',
-            lambda progress_callback: rebuild_calls.append(progress_callback) is None,
+            lambda progress_callback, initial_tag: rebuild_calls.append(progress_callback) is None,
         )
 
         assert git_service._fetch_remote() is True
         assert rebuild_calls == [None]
+
+    def test_tag_missing_object_rebuild_keeps_initial_tag(
+        self,
+        git_service: GitService,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        rebuild_calls: list[tuple[object, str | None]] = []
+
+        monkeypatch.setattr(
+            git_service,
+            '_fetch_remote_once',
+            lambda *args: (_ for _ in ()).throw(KeyError('object not found - no match for id')),
+        )
+        monkeypatch.setattr(git_service, '_restore_origin', lambda: True)
+        monkeypatch.setattr(
+            git_service,
+            '_rebuild_repository',
+            lambda progress_callback, initial_tag: rebuild_calls.append((progress_callback, initial_tag)) is None,
+        )
+
+        assert git_service._fetch_remote(tag_name='v1.0.0') is True
+        assert rebuild_calls == [(None, 'v1.0.0')]
 
     def test_missing_object_failure_rebuilds_when_origin_restore_fails(
         self,
@@ -1109,7 +1284,7 @@ class TestFetchProgressRemoteCallbacks:
         monkeypatch.setattr(
             git_service,
             '_rebuild_repository',
-            lambda progress_callback: rebuild_calls.append(progress_callback) is None,
+            lambda progress_callback, initial_tag: rebuild_calls.append(progress_callback) is None,
         )
 
         assert git_service._fetch_remote() is True
@@ -1135,7 +1310,7 @@ class TestFetchProgressRemoteCallbacks:
         monkeypatch.setattr(
             git_service,
             '_rebuild_repository',
-            lambda progress_callback: rebuild_calls.append(progress_callback) is None,
+            lambda progress_callback, initial_tag: rebuild_calls.append(progress_callback) is None,
         )
 
         assert git_service._fetch_remote() is True
@@ -1156,7 +1331,7 @@ class TestFetchProgressRemoteCallbacks:
         monkeypatch.setattr(
             git_service,
             '_rebuild_repository',
-            lambda progress_callback: rebuild_calls.append(progress_callback) is None,
+            lambda progress_callback, initial_tag: rebuild_calls.append(progress_callback) is None,
         )
 
         assert git_service._fetch_remote() is False
@@ -1189,7 +1364,7 @@ class TestFetchProgressRemoteCallbacks:
         assert (repo_path / '.git').is_dir()
         assert list(repo_path.glob('.git.corrupted.*')) == []
 
-    def test_rebuild_repository_backs_up_git_directory(
+    def test_rebuild_repository_backs_up_git_directory_and_keeps_initial_tag(
         self,
         monkeypatch: pytest.MonkeyPatch,
         tmp_path: Path,
@@ -1203,13 +1378,20 @@ class TestFetchProgressRemoteCallbacks:
             repo_dir=str(repo_path),
         )
 
-        def fake_clone(progress_callback: object) -> tuple[GitSyncStatus, str]:
+        received_tags: list[str | None] = []
+
+        def fake_clone(
+            progress_callback: object,
+            initial_tag: str | None,
+        ) -> tuple[GitSyncStatus, str]:
+            received_tags.append(initial_tag)
             pygit2.init_repository(str(repo_path))
             return GitSyncStatus.SUCCESS, 'ok'
 
         monkeypatch.setattr(git_service, '_clone_repository', fake_clone)
 
-        assert git_service._rebuild_repository(None) is True
+        assert git_service._rebuild_repository(None, 'v1.0.0') is True
+        assert received_tags == ['v1.0.0']
         assert (repo_path / '.git').is_dir()
         assert len(list(repo_path.glob('.git.corrupted.*'))) == 1
 

--- a/test/one_dragon/envs/test_git_service.py
+++ b/test/one_dragon/envs/test_git_service.py
@@ -901,7 +901,7 @@ class TestFetchProgressRemoteCallbacks:
         )
         monkeypatch.setattr(git_service, '_restore_origin', lambda: True)
 
-        assert git_service._fetch_remote() is True
+        assert git_service._fetch_remote()[0] is GitSyncStatus.SUCCESS
         assert worker_count == 2
         assert abandoned_states[0].is_set() is True
         assert abandoned_states[1].is_set() is False
@@ -960,7 +960,7 @@ class TestFetchProgressRemoteCallbacks:
         monkeypatch.setattr(git_service, '_fetch_remote_once', fake_fetch)
         monkeypatch.setattr(git_service, '_restore_origin', fake_restore)
 
-        assert git_service._fetch_remote() is True
+        assert git_service._fetch_remote()[0] is GitSyncStatus.SUCCESS
         assert attempted_urls == [
             'https://github.example/repo.git',
             'https://cnb.example/repo.git',
@@ -976,7 +976,7 @@ class TestFetchProgressRemoteCallbacks:
         monkeypatch.setattr(git_service, '_fetch_remote_once', lambda *args: None)
         monkeypatch.setattr(git_service, '_restore_origin', lambda: False)
 
-        assert git_service._fetch_remote() is False
+        assert git_service._fetch_remote()[0] is GitSyncStatus.LOCAL_UPDATE_FAILED
 
     def test_auto_source_records_successful_repository_when_manifest_rejects_update(
         self,
@@ -1023,7 +1023,9 @@ class TestFetchProgressRemoteCallbacks:
         monkeypatch.setattr(
             git_service,
             '_fetch_remote',
-            lambda progress_callback, stage_start, stage_end, tag_name: calls.append('fetch') is None,
+            lambda progress_callback, stage_start, stage_end, tag_name: (
+                calls.append('fetch') or (GitSyncStatus.SUCCESS, 'ok')
+            ),
         )
         monkeypatch.setattr(
             git_service,
@@ -1053,24 +1055,30 @@ class TestFetchProgressRemoteCallbacks:
         monkeypatch.setattr(
             git_service,
             '_fetch_remote',
-            lambda progress_callback, stage_start, stage_end, tag_name: calls.append(tag_name) or True,
+            lambda progress_callback, stage_start, stage_end, tag_name: (
+                calls.append(tag_name) or (GitSyncStatus.SUCCESS, 'ok')
+            ),
         )
         monkeypatch.setattr(
             git_service,
             '_check_remote_manifest_compatible',
             lambda: (_ for _ in ()).throw(AssertionError('按内置 tag 拉取不应再检查清单')),
         )
-        monkeypatch.setattr(git_service, '_checkout_branch', lambda: calls.append('checkout') or True)
+        monkeypatch.setattr(
+            git_service,
+            '_checkout_branch',
+            lambda: (calls.append('checkout') or (GitSyncStatus.SUCCESS, True, '')),
+        )
         monkeypatch.setattr(
             git_service,
             '_sync_with_remote',
-            lambda force: (calls.append(('sync', force)) is None, 'ok'),
+            lambda force: (calls.append(('sync', force)) or (GitSyncStatus.UP_TO_DATE, 'ok')),
         )
 
         status, message = git_service._clone_repository(initial_tag='v1.0.0')
 
         assert status is GitSyncStatus.SUCCESS
-        assert message == '克隆仓库成功'
+        assert message == '更新完成'
         assert calls == ['init', 'v1.0.0', 'checkout', ('sync', True)]
 
     def test_first_clone_keeps_builtin_code_when_tag_is_unavailable(
@@ -1083,14 +1091,16 @@ class TestFetchProgressRemoteCallbacks:
         monkeypatch.setattr(
             git_service,
             '_fetch_remote',
-            lambda progress_callback, stage_start, stage_end, tag_name: calls.append(tag_name) or False,
+            lambda progress_callback, stage_start, stage_end, tag_name: (
+                calls.append(tag_name) or (GitSyncStatus.REMOTE_UNAVAILABLE, '暂时无法获取更新')
+            ),
         )
         monkeypatch.setattr(git_service, '_checkout_branch', lambda: calls.append('checkout') is not None)
 
         status, message = git_service._clone_repository(initial_tag='v1.0.0')
 
         assert status is GitSyncStatus.BUILTIN_TAG_UNAVAILABLE
-        assert message == '未能获取内置版本对应的代码标签 v1.0.0'
+        assert message == '暂时无法获取当前版本所需文件'
         assert calls == ['init', 'v1.0.0']
 
     def test_fetch_latest_code_retries_builtin_tag_while_local_branch_is_missing(
@@ -1150,7 +1160,7 @@ class TestFetchProgressRemoteCallbacks:
         monkeypatch.setattr(git_service, '_restore_origin', lambda: True)
         git_service.env_config.last_repository_url = CNB_REPOSITORY.url
 
-        assert git_service._fetch_remote() is False
+        assert git_service._fetch_remote()[0] is GitSyncStatus.REMOTE_UNAVAILABLE
         assert git_service.env_config.last_repository_url == CNB_REPOSITORY.url
 
     def test_auto_source_prioritizes_last_successful_repository(self, git_service: GitService) -> None:
@@ -1222,7 +1232,7 @@ class TestFetchProgressRemoteCallbacks:
         )
         monkeypatch.setattr(git_service, '_restore_origin', lambda: True)
 
-        assert git_service._fetch_remote() is True
+        assert git_service._fetch_remote()[0] is GitSyncStatus.SUCCESS
         assert attempted_urls == ['https://proxy.example/https://github.example/repo.git']
         assert git_service.env_config.last_repository_url == GITHUB_REPOSITORY.url
 
@@ -1241,10 +1251,12 @@ class TestFetchProgressRemoteCallbacks:
         monkeypatch.setattr(
             git_service,
             '_rebuild_repository',
-            lambda progress_callback, initial_tag: rebuild_calls.append(progress_callback) is None,
+            lambda progress_callback, initial_tag: (
+                rebuild_calls.append(progress_callback) or (GitSyncStatus.SUCCESS, 'ok')
+            ),
         )
 
-        assert git_service._fetch_remote() is True
+        assert git_service._fetch_remote()[0] is GitSyncStatus.SUCCESS
         assert rebuild_calls == [None]
 
     def test_tag_missing_object_rebuild_keeps_initial_tag(
@@ -1263,10 +1275,12 @@ class TestFetchProgressRemoteCallbacks:
         monkeypatch.setattr(
             git_service,
             '_rebuild_repository',
-            lambda progress_callback, initial_tag: rebuild_calls.append((progress_callback, initial_tag)) is None,
+            lambda progress_callback, initial_tag: (
+                rebuild_calls.append((progress_callback, initial_tag)) or (GitSyncStatus.SUCCESS, 'ok')
+            ),
         )
 
-        assert git_service._fetch_remote(tag_name='v1.0.0') is True
+        assert git_service._fetch_remote(tag_name='v1.0.0')[0] is GitSyncStatus.SUCCESS
         assert rebuild_calls == [(None, 'v1.0.0')]
 
     def test_missing_object_failure_rebuilds_when_origin_restore_fails(
@@ -1284,10 +1298,12 @@ class TestFetchProgressRemoteCallbacks:
         monkeypatch.setattr(
             git_service,
             '_rebuild_repository',
-            lambda progress_callback, initial_tag: rebuild_calls.append(progress_callback) is None,
+            lambda progress_callback, initial_tag: (
+                rebuild_calls.append(progress_callback) or (GitSyncStatus.SUCCESS, 'ok')
+            ),
         )
 
-        assert git_service._fetch_remote() is True
+        assert git_service._fetch_remote()[0] is GitSyncStatus.SUCCESS
         assert rebuild_calls == [None]
 
     def test_missing_object_and_network_failure_trigger_repository_rebuild(
@@ -1310,10 +1326,12 @@ class TestFetchProgressRemoteCallbacks:
         monkeypatch.setattr(
             git_service,
             '_rebuild_repository',
-            lambda progress_callback, initial_tag: rebuild_calls.append(progress_callback) is None,
+            lambda progress_callback, initial_tag: (
+                rebuild_calls.append(progress_callback) or (GitSyncStatus.SUCCESS, 'ok')
+            ),
         )
 
-        assert git_service._fetch_remote() is True
+        assert git_service._fetch_remote()[0] is GitSyncStatus.SUCCESS
         assert rebuild_calls == [None]
 
     def test_network_failures_do_not_trigger_repository_rebuild(
@@ -1331,10 +1349,12 @@ class TestFetchProgressRemoteCallbacks:
         monkeypatch.setattr(
             git_service,
             '_rebuild_repository',
-            lambda progress_callback, initial_tag: rebuild_calls.append(progress_callback) is None,
+            lambda progress_callback, initial_tag: (
+                rebuild_calls.append(progress_callback) or (GitSyncStatus.SUCCESS, 'ok')
+            ),
         )
 
-        assert git_service._fetch_remote() is False
+        assert git_service._fetch_remote()[0] is GitSyncStatus.REMOTE_UNAVAILABLE
         assert rebuild_calls == []
 
     def test_rebuild_repository_skips_repository_with_extra_remote(
@@ -1359,7 +1379,7 @@ class TestFetchProgressRemoteCallbacks:
             lambda progress_callback: clone_calls.append(progress_callback),
         )
 
-        assert git_service._rebuild_repository(None) is False
+        assert git_service._rebuild_repository(None)[0] is GitSyncStatus.LOCAL_UPDATE_FAILED
         assert clone_calls == []
         assert (repo_path / '.git').is_dir()
         assert list(repo_path.glob('.git.corrupted.*')) == []
@@ -1390,7 +1410,7 @@ class TestFetchProgressRemoteCallbacks:
 
         monkeypatch.setattr(git_service, '_clone_repository', fake_clone)
 
-        assert git_service._rebuild_repository(None, 'v1.0.0') is True
+        assert git_service._rebuild_repository(None, 'v1.0.0')[0] is GitSyncStatus.SUCCESS
         assert received_tags == ['v1.0.0']
         assert (repo_path / '.git').is_dir()
         assert len(list(repo_path.glob('.git.corrupted.*'))) == 1

--- a/test/one_dragon/envs/test_git_sync_status.py
+++ b/test/one_dragon/envs/test_git_sync_status.py
@@ -1,0 +1,219 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import one_dragon.envs.git_service as git_service_module
+from one_dragon.envs.git_service import GitService, GitSyncStatus
+
+
+def test_status_values_are_neutral_user_messages() -> None:
+    assert {status: status.value for status in GitSyncStatus} == {
+        GitSyncStatus.SUCCESS: '更新完成',
+        GitSyncStatus.UP_TO_DATE: '当前已是最新版本',
+        GitSyncStatus.RUNTIME_INCOMPATIBLE: '新版本需要更新启动器才能使用',
+        GitSyncStatus.BUILTIN_TAG_UNAVAILABLE: '暂时无法获取当前版本所需文件',
+        GitSyncStatus.REMOTE_UNAVAILABLE: '暂时无法获取更新',
+        GitSyncStatus.LOCAL_CHANGES: '检测到程序文件有改动，未自动更新',
+        GitSyncStatus.LOCAL_UPDATE_FAILED: '更新没有完成',
+        GitSyncStatus.FAILED: '更新失败',
+    }
+
+
+def create_git_service(tmp_path: Path) -> GitService:
+    env_config = SimpleNamespace(
+        git_remote='origin',
+        git_branch='main',
+        force_update=False,
+    )
+    return GitService(
+        SimpleNamespace(),
+        env_config,
+        SimpleNamespace(),
+        repo_dir=str(tmp_path),
+    )
+
+
+@pytest.mark.parametrize(
+    ('branch_changed', 'expected_status', 'expected_message'),
+    [
+        (False, GitSyncStatus.UP_TO_DATE, '当前已是最新版本'),
+        (True, GitSyncStatus.SUCCESS, '更新完成'),
+    ],
+)
+def test_fetch_and_checkout_distinguishes_up_to_date_from_branch_switch(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    branch_changed: bool,
+    expected_status: GitSyncStatus,
+    expected_message: str,
+) -> None:
+    git_service = create_git_service(tmp_path)
+    monkeypatch.setattr(
+        git_service,
+        '_fetch_remote',
+        lambda progress_callback, stage_start, stage_end: (GitSyncStatus.SUCCESS, ''),
+    )
+    monkeypatch.setattr(git_service, '_check_remote_manifest_compatible', lambda: (True, ''))
+    monkeypatch.setattr(
+        git_service,
+        '_validate_working_directory',
+        lambda: (GitSyncStatus.SUCCESS, ''),
+    )
+    monkeypatch.setattr(
+        git_service,
+        '_checkout_branch',
+        lambda: (GitSyncStatus.SUCCESS, branch_changed, ''),
+    )
+    monkeypatch.setattr(
+        git_service,
+        '_sync_with_remote',
+        lambda force: (GitSyncStatus.UP_TO_DATE, '当前已是最新版本'),
+    )
+
+    status, message = git_service._fetch_and_checkout_latest_branch()
+
+    assert status is expected_status
+    assert message == expected_message
+
+
+def test_builtin_tag_does_not_hide_local_update_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    git_service = create_git_service(tmp_path)
+    monkeypatch.setattr(git_service_module, 'init_repository', lambda path: None)
+    monkeypatch.setattr(
+        git_service,
+        '_fetch_remote',
+        lambda progress_callback, stage_start, stage_end, tag_name: (
+            GitSyncStatus.LOCAL_UPDATE_FAILED,
+            '本地代码更新失败',
+        ),
+    )
+
+    status, message = git_service._clone_repository(initial_tag='v1.0.0')
+
+    assert status is GitSyncStatus.LOCAL_UPDATE_FAILED
+    assert message == '本地代码更新失败'
+
+
+def test_validate_working_directory_returns_local_changes(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    git_service = create_git_service(tmp_path)
+    monkeypatch.setattr(git_service, '_open_repo', lambda: SimpleNamespace(status=lambda: {'file.py': 1}))
+
+    status, message = git_service._validate_working_directory()
+
+    assert status is GitSyncStatus.LOCAL_CHANGES
+    assert message == '检测到程序文件有改动'
+
+
+def test_validate_working_directory_failure_is_local_update_failed(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    git_service = create_git_service(tmp_path)
+    monkeypatch.setattr(
+        git_service,
+        '_open_repo',
+        lambda: (_ for _ in ()).throw(RuntimeError('仓库不可读')),
+    )
+
+    status, message = git_service._validate_working_directory()
+
+    assert status is GitSyncStatus.LOCAL_UPDATE_FAILED
+    assert message == '检测当前代码状态失败'
+
+
+def test_sync_with_remote_returns_up_to_date_when_commit_is_unchanged(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    git_service = create_git_service(tmp_path)
+    monkeypatch.setattr(git_service, '_get_local_and_remote_oid', lambda: ('same', 'same', ''))
+
+    status, message = git_service._sync_with_remote(force=False)
+
+    assert status is GitSyncStatus.UP_TO_DATE
+    assert message == '当前已是最新版本'
+
+
+def test_sync_with_remote_returns_local_changes_when_update_cannot_fast_forward(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    git_service = create_git_service(tmp_path)
+    monkeypatch.setattr(git_service, '_get_local_and_remote_oid', lambda: ('local', 'remote', ''))
+    monkeypatch.setattr(
+        git_service,
+        '_open_repo',
+        lambda: SimpleNamespace(
+            descendant_of=lambda remote, local: False,
+            status=lambda: {},
+        ),
+    )
+
+    status, message = git_service._sync_with_remote(force=False)
+
+    assert status is GitSyncStatus.LOCAL_CHANGES
+    assert message == '检测到程序文件有改动'
+
+
+def test_checkout_failure_is_local_update_failed(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    git_service = create_git_service(tmp_path)
+    repo = SimpleNamespace(
+        head=SimpleNamespace(name='refs/heads/main'),
+        references={},
+    )
+    monkeypatch.setattr(git_service, '_open_repo', lambda: repo)
+
+    status, branch_changed, message = git_service._checkout_branch()
+
+    assert status is GitSyncStatus.LOCAL_UPDATE_FAILED
+    assert branch_changed is False
+    assert message == '切换到目标版本失败'
+
+
+def test_fetch_latest_code_returns_neutral_message_for_known_status(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    git_service = create_git_service(tmp_path)
+    monkeypatch.setattr(git_service, 'is_initial_checkout_pending', lambda: False)
+    monkeypatch.setattr(
+        git_service,
+        '_fetch_and_checkout_latest_branch',
+        lambda progress_callback: (
+            GitSyncStatus.RUNTIME_INCOMPATIBLE,
+            '目标版本的运行环境与当前不兼容',
+        ),
+    )
+
+    status, message = git_service.fetch_latest_code()
+
+    assert status is GitSyncStatus.RUNTIME_INCOMPATIBLE
+    assert message == '新版本需要更新启动器才能使用'
+
+
+def test_fetch_latest_code_uses_failed_only_for_unexpected_exception(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    git_service = create_git_service(tmp_path)
+    monkeypatch.setattr(git_service, 'is_initial_checkout_pending', lambda: False)
+    monkeypatch.setattr(
+        git_service,
+        '_fetch_and_checkout_latest_branch',
+        lambda progress_callback: (_ for _ in ()).throw(RuntimeError('意外错误')),
+    )
+
+    status, message = git_service.fetch_latest_code()
+
+    assert status is GitSyncStatus.FAILED
+    assert message == '更新失败'

--- a/test/one_dragon/test_code_sync_progress.py
+++ b/test/one_dragon/test_code_sync_progress.py
@@ -164,10 +164,10 @@ def test_runtime_launcher_sync_code_uses_framework_log(monkeypatch) -> None:
             self.progress_callback = None
             FakeGitService.instances.append(self)
 
-        def check_repo_exists(self) -> bool:
-            return True
+        def is_initial_checkout_pending(self) -> bool:
+            return False
 
-        def fetch_latest_code(self, progress_callback=None):
+        def fetch_latest_code(self, progress_callback=None, initial_tag=None):
             self.progress_callback = progress_callback
             progress_callback(0.3, '处理增量 3/10 (30%)')
             progress_callback(1.0, '处理增量 10/10 (100%), done.')
@@ -205,10 +205,10 @@ def test_runtime_launcher_first_clone_continues_on_runtime_incompatible(monkeypa
     exit_calls: list[int] = []
 
     class FakeGitService:
-        def check_repo_exists(self) -> bool:
-            return False
+        def is_initial_checkout_pending(self) -> bool:
+            return True
 
-        def fetch_latest_code(self, progress_callback=None):
+        def fetch_latest_code(self, progress_callback=None, initial_tag=None):
             return (
                 git_service_module.GitSyncStatus.RUNTIME_INCOMPATIBLE,
                 '目标版本的运行环境与当前不兼容',
@@ -231,3 +231,42 @@ def test_runtime_launcher_first_clone_continues_on_runtime_incompatible(monkeypa
 
     assert exit_calls == []
     assert warnings == ['目标版本的运行环境与当前不兼容，继续使用当前代码；请更新集成启动器']
+
+
+def test_runtime_launcher_retries_builtin_release_tag_until_first_checkout(monkeypatch) -> None:
+    warnings: list[str] = []
+    received_tags: list[str | None] = []
+
+    class FakeGitService:
+        def is_initial_checkout_pending(self) -> bool:
+            return True
+
+        def fetch_latest_code(self, progress_callback=None, initial_tag=None):
+            received_tags.append(initial_tag)
+            return (
+                git_service_module.GitSyncStatus.BUILTIN_TAG_UNAVAILABLE,
+                f'未能获取内置版本对应的代码标签 {initial_tag}',
+            )
+
+    monkeypatch.setattr(
+        env_context_module,
+        'OneDragonEnvContext',
+        lambda: SimpleNamespace(
+            env_config=SimpleNamespace(auto_update_code=True),
+            git_service=FakeGitService(),
+        ),
+    )
+    monkeypatch.setattr('one_dragon.version.__version__', 'v1.2.3')
+    monkeypatch.setattr(i18_utils_module, 'gt', lambda message: message)
+    monkeypatch.setattr('one_dragon.utils.log_utils.log.info', lambda message: None)
+    monkeypatch.setattr('one_dragon.utils.log_utils.log.warning', warnings.append)
+
+    launcher = RuntimeLauncher('test', '1.0.0')
+    launcher._sync_code()
+    launcher._sync_code()
+
+    assert received_tags == ['v1.2.3', 'v1.2.3']
+    assert warnings == [
+        '未能获取内置版本对应的代码标签 v1.2.3，继续使用当前代码；请更新集成启动器',
+        '未能获取内置版本对应的代码标签 v1.2.3，继续使用当前代码；请更新集成启动器',
+    ]

--- a/test/one_dragon/test_code_sync_progress.py
+++ b/test/one_dragon/test_code_sync_progress.py
@@ -1,5 +1,7 @@
 from types import SimpleNamespace
 
+import pytest
+
 import one_dragon.base.operation.one_dragon_env_context as env_context_module
 import one_dragon.devtools.python_launcher as python_launcher
 import one_dragon.envs.git_service as git_service_module
@@ -58,7 +60,10 @@ def test_python_launcher_fetch_latest_code_passes_progress_callback(
             self.progress_callback = progress_callback
             progress_callback(0.421, '拉取对象 3/10 (30%)')
             progress_callback(0.500, '检查运行环境兼容性')
-            return git_service_module.GitSyncStatus.SUCCESS, ''
+            return (
+                git_service_module.GitSyncStatus.SUCCESS,
+                git_service_module.GitSyncStatus.SUCCESS.value,
+            )
 
     git_service = FakeGitService()
     ctx = SimpleNamespace(
@@ -77,7 +82,7 @@ def test_python_launcher_fetch_latest_code_passes_progress_callback(
     assert git_service.progress_callback is not None
     assert ('INFO', '拉取对象 3/10 (30%)') in messages
     assert ('INFO', '检查运行环境兼容性') in messages
-    assert ('PASS', '代码更新完成') in messages
+    assert ('PASS', '更新完成') in messages
 
 
 def test_python_launcher_fetch_latest_code_silences_framework_console_log(
@@ -89,7 +94,10 @@ def test_python_launcher_fetch_latest_code_silences_framework_console_log(
 
         def fetch_latest_code(self, progress_callback=None):
             progress_callback(0.500, '检查运行环境兼容性')
-            return git_service_module.GitSyncStatus.SUCCESS, ''
+            return (
+                git_service_module.GitSyncStatus.SUCCESS,
+                git_service_module.GitSyncStatus.SUCCESS.value,
+            )
 
     messages: list[tuple[str, str]] = []
     ctx = SimpleNamespace(
@@ -127,6 +135,66 @@ def test_python_launcher_fetch_latest_code_silences_framework_console_log(
     assert configured[0][2] is False
     assert configured[0][3] is False
     assert ('INFO', '检查运行环境兼容性') in messages
+
+
+@pytest.mark.parametrize(
+    ('status', 'expected_level', 'expected_message'),
+    [
+        (git_service_module.GitSyncStatus.SUCCESS, 'PASS', '更新完成'),
+        (git_service_module.GitSyncStatus.UP_TO_DATE, 'PASS', '当前已是最新版本'),
+        (
+            git_service_module.GitSyncStatus.RUNTIME_INCOMPATIBLE,
+            'WARNING',
+            '新版本需要更新启动器才能使用，继续使用当前版本',
+        ),
+        (
+            git_service_module.GitSyncStatus.BUILTIN_TAG_UNAVAILABLE,
+            'WARNING',
+            '暂时无法获取当前版本所需文件，继续使用内置版本',
+        ),
+        (
+            git_service_module.GitSyncStatus.REMOTE_UNAVAILABLE,
+            'WARNING',
+            '暂时无法获取更新，继续使用当前版本',
+        ),
+        (
+            git_service_module.GitSyncStatus.LOCAL_CHANGES,
+            'WARNING',
+            '检测到程序文件有改动，未自动更新，继续使用当前版本',
+        ),
+        (
+            git_service_module.GitSyncStatus.LOCAL_UPDATE_FAILED,
+            'ERROR',
+            '更新没有完成，请重新运行启动器；仍然失败时请重新安装',
+        ),
+        (git_service_module.GitSyncStatus.FAILED, 'ERROR', '更新失败，请查看日志后重试'),
+    ],
+)
+def test_python_launcher_uses_status_specific_result_message(
+    monkeypatch: pytest.MonkeyPatch,
+    status: git_service_module.GitSyncStatus,
+    expected_level: str,
+    expected_message: str,
+) -> None:
+    class FakeGitService:
+        def fetch_latest_code(self, progress_callback=None):
+            return status, status.value
+
+    messages: list[tuple[str, str]] = []
+    ctx = SimpleNamespace(
+        env_config=SimpleNamespace(auto_update_code=True),
+        git_service=FakeGitService(),
+    )
+    monkeypatch.setattr(python_launcher, '_configure_runtime_logger', lambda: None)
+    monkeypatch.setattr(
+        python_launcher,
+        'print_message',
+        lambda message, level='INFO', flush=False: messages.append((level, message)),
+    )
+
+    python_launcher.fetch_latest_code(ctx)
+
+    assert messages[-1] == (expected_level, expected_message)
 
 
 def test_python_launcher_progress_callback_passes_stage_messages_through() -> None:
@@ -171,7 +239,10 @@ def test_runtime_launcher_sync_code_uses_framework_log(monkeypatch) -> None:
             self.progress_callback = progress_callback
             progress_callback(0.3, '处理增量 3/10 (30%)')
             progress_callback(1.0, '处理增量 10/10 (100%), done.')
-            return git_service_module.GitSyncStatus.SUCCESS, ''
+            return (
+                git_service_module.GitSyncStatus.SUCCESS,
+                git_service_module.GitSyncStatus.SUCCESS.value,
+            )
 
     print_calls: list[tuple[str, str, bool]] = []
 
@@ -197,7 +268,7 @@ def test_runtime_launcher_sync_code_uses_framework_log(monkeypatch) -> None:
     assert '处理增量 10/10 (100%), done.' in messages
     assert print_calls[0] == ('处理增量 3/10 (30%)', '\r', True)
     assert print_calls[1] == (' ' * 120, '\r', True)
-    assert '代码更新检查完成' in messages
+    assert '更新完成' in messages
 
 
 def test_runtime_launcher_first_clone_continues_on_runtime_incompatible(monkeypatch) -> None:
@@ -211,7 +282,7 @@ def test_runtime_launcher_first_clone_continues_on_runtime_incompatible(monkeypa
         def fetch_latest_code(self, progress_callback=None, initial_tag=None):
             return (
                 git_service_module.GitSyncStatus.RUNTIME_INCOMPATIBLE,
-                '目标版本的运行环境与当前不兼容',
+                git_service_module.GitSyncStatus.RUNTIME_INCOMPATIBLE.value,
             )
 
     monkeypatch.setattr(
@@ -230,7 +301,7 @@ def test_runtime_launcher_first_clone_continues_on_runtime_incompatible(monkeypa
     RuntimeLauncher('test', '1.0.0')._sync_code()
 
     assert exit_calls == []
-    assert warnings == ['目标版本的运行环境与当前不兼容，继续使用当前代码；请更新集成启动器']
+    assert warnings == ['新版本需要更新启动器才能使用，继续使用当前版本']
 
 
 def test_runtime_launcher_retries_builtin_release_tag_until_first_checkout(monkeypatch) -> None:
@@ -245,7 +316,7 @@ def test_runtime_launcher_retries_builtin_release_tag_until_first_checkout(monke
             received_tags.append(initial_tag)
             return (
                 git_service_module.GitSyncStatus.BUILTIN_TAG_UNAVAILABLE,
-                f'未能获取内置版本对应的代码标签 {initial_tag}',
+                git_service_module.GitSyncStatus.BUILTIN_TAG_UNAVAILABLE.value,
             )
 
     monkeypatch.setattr(
@@ -267,6 +338,165 @@ def test_runtime_launcher_retries_builtin_release_tag_until_first_checkout(monke
 
     assert received_tags == ['v1.2.3', 'v1.2.3']
     assert warnings == [
-        '未能获取内置版本对应的代码标签 v1.2.3，继续使用当前代码；请更新集成启动器',
-        '未能获取内置版本对应的代码标签 v1.2.3，继续使用当前代码；请更新集成启动器',
+        '暂时无法获取当前版本所需文件，继续使用内置版本',
+        '暂时无法获取当前版本所需文件，继续使用内置版本',
     ]
+
+
+def test_runtime_launcher_up_to_date_does_not_clear_modules(monkeypatch: pytest.MonkeyPatch) -> None:
+    info_messages: list[str] = []
+    clear_calls: list[set[str]] = []
+
+    class FakeGitService:
+        def is_initial_checkout_pending(self) -> bool:
+            return False
+
+        def fetch_latest_code(self, progress_callback=None, initial_tag=None):
+            return (
+                git_service_module.GitSyncStatus.UP_TO_DATE,
+                git_service_module.GitSyncStatus.UP_TO_DATE.value,
+            )
+
+    monkeypatch.setattr(
+        env_context_module,
+        'OneDragonEnvContext',
+        lambda: SimpleNamespace(
+            env_config=SimpleNamespace(auto_update_code=True),
+            git_service=FakeGitService(),
+        ),
+    )
+    monkeypatch.setattr(i18_utils_module, 'gt', lambda message: message)
+    monkeypatch.setattr('one_dragon.utils.log_utils.log.info', info_messages.append)
+    monkeypatch.setattr(
+        RuntimeLauncher,
+        '_clear_src_modules',
+        lambda self, modules: clear_calls.append(modules),
+    )
+
+    RuntimeLauncher('test', '1.0.0')._sync_code()
+
+    assert '当前已是最新版本' in info_messages
+    assert clear_calls == []
+
+
+@pytest.mark.parametrize(
+    ('status', 'expected_warning'),
+    [
+        (git_service_module.GitSyncStatus.REMOTE_UNAVAILABLE, '暂时无法获取更新，继续使用当前版本'),
+        (
+            git_service_module.GitSyncStatus.LOCAL_CHANGES,
+            '检测到程序文件有改动，未自动更新，继续使用当前版本',
+        ),
+    ],
+)
+def test_runtime_launcher_continues_when_existing_code_is_safe(
+    monkeypatch: pytest.MonkeyPatch,
+    status: git_service_module.GitSyncStatus,
+    expected_warning: str,
+) -> None:
+    warnings: list[str] = []
+    exit_calls: list[int] = []
+
+    class FakeGitService:
+        def is_initial_checkout_pending(self) -> bool:
+            return False
+
+        def fetch_latest_code(self, progress_callback=None, initial_tag=None):
+            return status, status.value
+
+    monkeypatch.setattr(
+        env_context_module,
+        'OneDragonEnvContext',
+        lambda: SimpleNamespace(
+            env_config=SimpleNamespace(auto_update_code=True),
+            git_service=FakeGitService(),
+        ),
+    )
+    monkeypatch.setattr(i18_utils_module, 'gt', lambda message: message)
+    monkeypatch.setattr('one_dragon.utils.log_utils.log.info', lambda message: None)
+    monkeypatch.setattr('one_dragon.utils.log_utils.log.warning', warnings.append)
+    monkeypatch.setattr('one_dragon.launcher.runtime_launcher.sys.exit', exit_calls.append)
+
+    RuntimeLauncher('test', '1.0.0')._sync_code()
+
+    assert warnings == [expected_warning]
+    assert exit_calls == []
+
+
+@pytest.mark.parametrize(
+    ('status', 'expected_error'),
+    [
+        (
+            git_service_module.GitSyncStatus.LOCAL_UPDATE_FAILED,
+            '更新没有完成，请重新运行启动器；仍然失败时请重新安装',
+        ),
+        (git_service_module.GitSyncStatus.FAILED, '更新失败，请查看日志后重试'),
+    ],
+)
+@pytest.mark.parametrize('first_run', [True, False])
+def test_runtime_launcher_stops_when_local_code_may_be_incomplete(
+    monkeypatch: pytest.MonkeyPatch,
+    status: git_service_module.GitSyncStatus,
+    expected_error: str,
+    first_run: bool,
+) -> None:
+    errors: list[str] = []
+    exit_calls: list[int] = []
+
+    class FakeGitService:
+        def is_initial_checkout_pending(self) -> bool:
+            return first_run
+
+        def fetch_latest_code(self, progress_callback=None, initial_tag=None):
+            return status, status.value
+
+    monkeypatch.setattr(
+        env_context_module,
+        'OneDragonEnvContext',
+        lambda: SimpleNamespace(
+            env_config=SimpleNamespace(auto_update_code=True),
+            git_service=FakeGitService(),
+        ),
+    )
+    monkeypatch.setattr(i18_utils_module, 'gt', lambda message: message)
+    monkeypatch.setattr('one_dragon.utils.log_utils.log.info', lambda message: None)
+    monkeypatch.setattr('one_dragon.utils.log_utils.log.error', errors.append)
+    monkeypatch.setattr('one_dragon.launcher.runtime_launcher.sys.exit', exit_calls.append)
+
+    RuntimeLauncher('test', '1.0.0')._sync_code()
+
+    assert errors == [expected_error]
+    assert exit_calls == [1]
+
+
+def test_runtime_launcher_stops_when_first_fetch_is_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
+    errors: list[str] = []
+    exit_calls: list[int] = []
+
+    class FakeGitService:
+        def is_initial_checkout_pending(self) -> bool:
+            return True
+
+        def fetch_latest_code(self, progress_callback=None, initial_tag=None):
+            return (
+                git_service_module.GitSyncStatus.REMOTE_UNAVAILABLE,
+                git_service_module.GitSyncStatus.REMOTE_UNAVAILABLE.value,
+            )
+
+    monkeypatch.setattr(
+        env_context_module,
+        'OneDragonEnvContext',
+        lambda: SimpleNamespace(
+            env_config=SimpleNamespace(auto_update_code=True),
+            git_service=FakeGitService(),
+        ),
+    )
+    monkeypatch.setattr(i18_utils_module, 'gt', lambda message: message)
+    monkeypatch.setattr('one_dragon.utils.log_utils.log.info', lambda message: None)
+    monkeypatch.setattr('one_dragon.utils.log_utils.log.error', errors.append)
+    monkeypatch.setattr('one_dragon.launcher.runtime_launcher.sys.exit', exit_calls.append)
+
+    RuntimeLauncher('test', '1.0.0')._sync_code()
+
+    assert errors == ['暂时无法获取更新，请稍后重试或切换代码源']
+    assert exit_calls == [1]

--- a/test/one_dragon/test_code_sync_progress.py
+++ b/test/one_dragon/test_code_sync_progress.py
@@ -58,7 +58,7 @@ def test_python_launcher_fetch_latest_code_passes_progress_callback(
             self.progress_callback = progress_callback
             progress_callback(0.421, '拉取对象 3/10 (30%)')
             progress_callback(0.500, '检查运行环境兼容性')
-            return True, ''
+            return git_service_module.GitSyncStatus.SUCCESS, ''
 
     git_service = FakeGitService()
     ctx = SimpleNamespace(
@@ -89,7 +89,7 @@ def test_python_launcher_fetch_latest_code_silences_framework_console_log(
 
         def fetch_latest_code(self, progress_callback=None):
             progress_callback(0.500, '检查运行环境兼容性')
-            return True, ''
+            return git_service_module.GitSyncStatus.SUCCESS, ''
 
     messages: list[tuple[str, str]] = []
     ctx = SimpleNamespace(
@@ -171,7 +171,7 @@ def test_runtime_launcher_sync_code_uses_framework_log(monkeypatch) -> None:
             self.progress_callback = progress_callback
             progress_callback(0.3, '处理增量 3/10 (30%)')
             progress_callback(1.0, '处理增量 10/10 (100%), done.')
-            return True, ''
+            return git_service_module.GitSyncStatus.SUCCESS, ''
 
     print_calls: list[tuple[str, str, bool]] = []
 
@@ -198,3 +198,36 @@ def test_runtime_launcher_sync_code_uses_framework_log(monkeypatch) -> None:
     assert print_calls[0] == ('处理增量 3/10 (30%)', '\r', True)
     assert print_calls[1] == (' ' * 120, '\r', True)
     assert '代码更新检查完成' in messages
+
+
+def test_runtime_launcher_first_clone_continues_on_runtime_incompatible(monkeypatch) -> None:
+    warnings: list[str] = []
+    exit_calls: list[int] = []
+
+    class FakeGitService:
+        def check_repo_exists(self) -> bool:
+            return False
+
+        def fetch_latest_code(self, progress_callback=None):
+            return (
+                git_service_module.GitSyncStatus.RUNTIME_INCOMPATIBLE,
+                '目标版本的运行环境与当前不兼容',
+            )
+
+    monkeypatch.setattr(
+        env_context_module,
+        'OneDragonEnvContext',
+        lambda: SimpleNamespace(
+            env_config=SimpleNamespace(auto_update_code=True),
+            git_service=FakeGitService(),
+        ),
+    )
+    monkeypatch.setattr(i18_utils_module, 'gt', lambda message: message)
+    monkeypatch.setattr('one_dragon.utils.log_utils.log.info', lambda message: None)
+    monkeypatch.setattr('one_dragon.utils.log_utils.log.warning', warnings.append)
+    monkeypatch.setattr('one_dragon.launcher.runtime_launcher.sys.exit', exit_calls.append)
+
+    RuntimeLauncher('test', '1.0.0')._sync_code()
+
+    assert exit_calls == []
+    assert warnings == ['目标版本的运行环境与当前不兼容，继续使用当前代码；请更新集成启动器']

--- a/test/one_dragon_qt/widgets/install_card/test_code_install_card.py
+++ b/test/one_dragon_qt/widgets/install_card/test_code_install_card.py
@@ -1,0 +1,117 @@
+import os
+from types import SimpleNamespace
+
+os.environ.setdefault('QT_QPA_PLATFORM', 'offscreen')
+
+import pytest
+from PySide6.QtWidgets import QApplication
+
+import one_dragon_qt.view.code_interface as code_interface_module
+from one_dragon.envs.git_service import GitSyncStatus
+from one_dragon_qt.widgets.install_card.base_install_card import InstallRunner
+from one_dragon_qt.widgets.install_card.code_install_card import CodeInstallCard
+
+
+@pytest.mark.parametrize(
+    ('status', 'expected_success'),
+    [
+        (GitSyncStatus.SUCCESS, True),
+        (GitSyncStatus.UP_TO_DATE, True),
+        (GitSyncStatus.RUNTIME_INCOMPATIBLE, False),
+        (GitSyncStatus.BUILTIN_TAG_UNAVAILABLE, False),
+        (GitSyncStatus.REMOTE_UNAVAILABLE, False),
+        (GitSyncStatus.LOCAL_CHANGES, False),
+        (GitSyncStatus.LOCAL_UPDATE_FAILED, False),
+        (GitSyncStatus.FAILED, False),
+    ],
+)
+def test_fetch_latest_code_keeps_status_for_display(
+    status: GitSyncStatus,
+    expected_success: bool,
+) -> None:
+    def progress_callback(progress: float, message: str) -> None:
+        pass
+
+    git_service = SimpleNamespace(
+        fetch_latest_code=lambda callback: (status, '同步结果'),
+    )
+    card = SimpleNamespace(
+        ctx=SimpleNamespace(git_service=git_service),
+        _last_sync_status=GitSyncStatus.FAILED,
+    )
+
+    success, message = CodeInstallCard.fetch_latest_code(card, progress_callback)
+
+    assert success is expected_success
+    assert message == '同步结果'
+    assert card._last_sync_status is status
+
+
+def test_install_runner_receives_success_bool_from_code_card() -> None:
+    _app = QApplication.instance() or QApplication([])
+    received: list[tuple[bool, str]] = []
+    git_service = SimpleNamespace(
+        fetch_latest_code=lambda callback: (GitSyncStatus.UP_TO_DATE, '当前已是最新版本'),
+    )
+    card = SimpleNamespace(
+        ctx=SimpleNamespace(git_service=git_service),
+        _last_sync_status=GitSyncStatus.FAILED,
+    )
+    runner = InstallRunner(lambda callback: CodeInstallCard.fetch_latest_code(card, callback))
+    runner.finished.connect(lambda success, message: received.append((success, message)))
+
+    runner.run()
+
+    assert received == [(True, '当前已是最新版本')]
+    assert card._last_sync_status is GitSyncStatus.UP_TO_DATE
+
+
+@pytest.mark.parametrize(
+    ('status', 'expected_message'),
+    [
+        (GitSyncStatus.SUCCESS, '更新完成，重启后生效'),
+        (GitSyncStatus.UP_TO_DATE, '当前已是最新版本'),
+        (GitSyncStatus.RUNTIME_INCOMPATIBLE, '新版本需要更新启动器才能使用，请先更新启动器'),
+        (GitSyncStatus.BUILTIN_TAG_UNAVAILABLE, '暂时无法获取当前版本所需文件，请稍后重试'),
+        (GitSyncStatus.REMOTE_UNAVAILABLE, '暂时无法获取更新，请稍后重试或切换代码源'),
+        (GitSyncStatus.LOCAL_CHANGES, '检测到程序文件有改动，未自动更新。可开启“强制更新”后重试'),
+        (GitSyncStatus.LOCAL_UPDATE_FAILED, '更新没有完成，请重启后重试；仍然失败时请重新安装'),
+        (GitSyncStatus.FAILED, '更新失败，请稍后重试；仍然失败时请查看日志'),
+    ],
+)
+def test_sync_status_uses_user_facing_message(
+    status: GitSyncStatus,
+    expected_message: str,
+) -> None:
+    messages: list[str] = []
+    card = SimpleNamespace(
+        updated=False,
+        _last_sync_status=status,
+        update_display=lambda icon, message: messages.append(message),
+    )
+
+    CodeInstallCard.after_progress_done(
+        card,
+        status in (GitSyncStatus.SUCCESS, GitSyncStatus.UP_TO_DATE),
+        status.value,
+    )
+
+    assert messages == [expected_message]
+    assert 'tag' not in messages[0]
+    assert 'checkout' not in messages[0]
+    assert 'reset' not in messages[0]
+    assert '安装器' not in messages[0]
+    assert card.updated is (status is GitSyncStatus.SUCCESS)
+
+
+def test_up_to_date_does_not_open_restart_dialog(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        code_interface_module,
+        'Dialog',
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError('已是最新时不应弹出重启提示')),
+    )
+    interface = SimpleNamespace(
+        code_card=SimpleNamespace(last_sync_status=GitSyncStatus.UP_TO_DATE),
+    )
+
+    code_interface_module.CodeInterface._show_dialog_after_code_updated(interface, True)


### PR DESCRIPTION
## 变更

- 覆盖 Git 拉取超时、临时仓清理、对象缺失重建与同步状态
- 覆盖正式发布包首次按内置版本初始化，且不可用时不退化到最新分支
- 覆盖 `GitSyncStatus` 中性用户文案，以及代码卡、集成启动器和命令行启动器的状态行为
- 区分实际更新与当前已是最新，验证 Qt 布尔信号和重启提示行为

## 验证

- 定向 pytest：53 passed
- ruff：通过
- compileall：通过
- `git diff --check`：通过

## 关联

配套主仓 `git-remote-fallback` 工作树中的 Git 同步状态与用户文案改动。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug 修复**
  * 改进代码同步过程中对网络异常、运行环境不兼容、本地修改及仓库损坏等情况的处理。
  * 优化仓库重建、重试和内置版本拉取，提升更新成功率。
  * 修正同步状态、完成提示及重启提示的显示逻辑。

* **体验优化**
  * 提供更清晰、准确的同步进度与结果提示。
  * 最新版本无需更新时，不再弹出不必要的重启对话框。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->