### PR TITLE
test(lost_void): 覆盖放弃组语义与六级优先级模型

### DIFF
--- a/test/one_dragon/operation/test_standalone_app_registration.py
+++ b/test/one_dragon/operation/test_standalone_app_registration.py
@@ -1,0 +1,24 @@
+from unittest.mock import MagicMock
+
+from one_dragon.base.operation.application.application_run_context import (
+    ApplicationRunContext,
+)
+
+
+def test_registry_application_only_exposes_default_or_standalone_apps() -> None:
+    """应用运行只显示默认组和显式声明 STANDALONE 的应用。"""
+    run_context = ApplicationRunContext(MagicMock())
+    default_factory = MagicMock(app_id='default_app', standalone=False)
+    standalone_factory = MagicMock(app_id='standalone_app', standalone=True)
+    internal_factory = MagicMock(app_id='internal_app', standalone=False)
+
+    run_context.registry_application(default_factory, default_group=True)
+    run_context.registry_application(standalone_factory, default_group=False)
+    run_context.registry_application(internal_factory, default_group=False)
+
+    assert run_context.default_group_apps == ['default_app']
+    assert run_context.standalone_app_ids == ['default_app', 'standalone_app']
+
+    run_context.clear_applications()
+
+    assert run_context.standalone_app_ids == []

--- a/test/zzz_od/application/hollow_zero/lost_void/lost_void_context/test_get_artifact_by_priority.py
+++ b/test/zzz_od/application/hollow_zero/lost_void/lost_void_context/test_get_artifact_by_priority.py
@@ -59,3 +59,106 @@ class TestGetArtifactByPriority:
             consider_not_in_priority=True)
         assert 1 == len(priority_list)
         assert '[终结]蓄势架子鼓' == priority_list[0].artifact.display_name
+
+    def test_priority_hit_ignores_abandon_list(self, test_context: TestContext):
+        """
+        修复：优先级规则命中时, 即使该分类在动态放弃组中, 也应正常选中。
+        放弃组只应作用于兜底补位阶段, 不应否决优先级规则匹配。
+        """
+        test_context.lost_void.load_artifact_data()
+        test_context.lost_void.load_challenge_config()
+
+        test_context.lost_void.dynamic_priority_list = []
+        test_context.lost_void.dynamic_abandon_list = ['击破']
+
+        test_context.lost_void.challenge_config.update(
+            'artifact_priority',
+            ['击破'],
+            save=False
+        )
+
+        art_name_list = ['[异常·击破]溶剂弹射枪', '[机敏]高效保险杠']
+        art_list: list[LostVoidArtifactPos] = []
+        for idx, art_name in enumerate(art_name_list):
+            art = test_context.lost_void.get_artifact_by_full_name(art_name)
+            assert art is not None, f'藏品数据缺失: {art_name}'
+            min_x = 300 * idx
+            max_x = min_x + 10
+            pos = LostVoidArtifactPos(art, Rect(min_x, min_x, max_x, max_x))
+            art_list.append(pos)
+
+        priority_list = test_context.lost_void.get_artifact_by_priority(
+            art_list, 1,
+            consider_priority_1=True, consider_priority_2=False,
+            consider_not_in_priority=False)
+        assert 1 == len(priority_list)
+        assert '[异常·击破]溶剂弹射枪' == priority_list[0].artifact.display_name
+
+    def test_abandon_list_only_for_fallback(self, test_context: TestContext):
+        """
+        放弃组只在兜底补位阶段生效：无优先级命中时, 先选不在放弃组的, 放弃组排最后。
+        """
+        test_context.lost_void.load_artifact_data()
+        test_context.lost_void.load_challenge_config()
+
+        test_context.lost_void.dynamic_priority_list = []
+        test_context.lost_void.dynamic_abandon_list = ['击破']
+
+        test_context.lost_void.challenge_config.update(
+            'artifact_priority',
+            ['星见雅 心间舞雀'],
+            save=False
+        )
+
+        art_name_list = ['[异常·击破]溶剂弹射枪', '[机敏]高效保险杠']
+        art_list: list[LostVoidArtifactPos] = []
+        for idx, art_name in enumerate(art_name_list):
+            art = test_context.lost_void.get_artifact_by_full_name(art_name)
+            assert art is not None, f'藏品数据缺失: {art_name}'
+            min_x = 300 * idx
+            max_x = min_x + 10
+            pos = LostVoidArtifactPos(art, Rect(min_x, min_x, max_x, max_x))
+            art_list.append(pos)
+
+        priority_list = test_context.lost_void.get_artifact_by_priority(
+            art_list, 1,
+            consider_priority_1=True, consider_priority_2=False,
+            consider_not_in_priority=True)
+        assert 1 == len(priority_list)
+        assert '[机敏]高效保险杠' == priority_list[0].artifact.display_name
+
+    def test_battle_priority_is_level_4(self, test_context: TestContext):
+        """
+        六级模型：第 2 级（配置一）优先于第 4 级（战斗组）。
+        配置一命中时, 即使战斗组也在, 也应先选配置一命中的藏品。
+        """
+        test_context.lost_void.load_artifact_data()
+        test_context.lost_void.load_challenge_config()
+
+        test_context.lost_void.dynamic_priority_list = []
+        test_context.lost_void.dynamic_abandon_list = []
+
+        test_context.lost_void.challenge_config.update(
+            'artifact_priority',
+            ['机敏'],
+            save=False
+        )
+        test_context.lost_void.challenge_config.clear_artifact_priority_in_battle()
+        test_context.lost_void.challenge_config.artifact_priority_in_battle.append('击破')
+
+        art_name_list = ['[异常·击破]溶剂弹射枪', '[机敏]高效保险杠']
+        art_list: list[LostVoidArtifactPos] = []
+        for idx, art_name in enumerate(art_name_list):
+            art = test_context.lost_void.get_artifact_by_full_name(art_name)
+            assert art is not None, f'藏品数据缺失: {art_name}'
+            min_x = 300 * idx
+            max_x = min_x + 10
+            pos = LostVoidArtifactPos(art, Rect(min_x, min_x, max_x, max_x))
+            art_list.append(pos)
+
+        priority_list = test_context.lost_void.get_artifact_by_priority(
+            art_list, 1,
+            consider_priority_1=True, consider_priority_2=True,
+            consider_not_in_priority=False)
+        assert 1 == len(priority_list)
+        assert '[机敏]高效保险杠' == priority_list[0].artifact.display_name

--- a/test/zzz_od/operation/test_choose_predefined_team_log.py
+++ b/test/zzz_od/operation/test_choose_predefined_team_log.py
@@ -1,0 +1,24 @@
+from unittest.mock import MagicMock, patch
+
+from zzz_od.operation.choose_predefined_team import ChoosePredefinedTeam
+
+
+def test_team_disabled_details_are_logged_at_debug_level() -> None:
+    """禁用判定的槽位和头像细节只在 DEBUG 级别输出。"""
+    operation = ChoosePredefinedTeam.__new__(ChoosePredefinedTeam)
+    agent_scan_result_list = [
+        MagicMock(is_dim=False),
+        MagicMock(is_dim=True),
+        MagicMock(is_dim=False),
+    ]
+
+    with patch('zzz_od.operation.choose_predefined_team.log') as log:
+        assert operation._is_team_disabled(
+            '编队1',
+            {'1P', '3P'},
+            3,
+            agent_scan_result_list,
+        )
+
+    log.debug.assert_called_once()
+    log.info.assert_not_called()


### PR DESCRIPTION
## 配对 PR

主仓 PR：[OneDragon-Anything/ZenlessZoneZero-OneDragon#2649](https://github.com/OneDragon-Anything/ZenlessZoneZero-OneDragon/pull/2649)

## 内容

`test_get_artifact_by_priority.py` 新增 3 个用例，覆盖六级优先级模型修复：

- `test_priority_hit_ignores_abandon_list`：优先级命中且分类在放弃组 → 仍购买（本次 bug 核心回归）
- `test_abandon_list_only_for_fallback`：放弃组只作用于兜底补位阶段，无优先级命中时先选非放弃组藏品
- `test_battle_priority_is_level_4`：配置一（第 2 级）优先于战斗组（第 4 级）

---
*本 PR 由 fairy（绝区零的 AI）撰写。*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **测试**
  * 新增独立应用注册与清理流程测试，覆盖默认、显式独立及普通内部应用的识别。
  * 增加遗器优先级、放弃列表兜底及战斗组优先级测试。
  * 新增队伍禁用判定日志测试，验证调试信息输出及日志级别行为。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->