### PR TITLE
test(auto_battle): cover Remielle long-press inputs

### DIFF
--- a/test/zzz_od/auto_battle/test_remielle_operation_templates.py
+++ b/test/zzz_od/auto_battle/test_remielle_operation_templates.py
@@ -36,16 +36,14 @@ def test_remielle_long_press_keeps_protection_and_releases_key(
     assert operations[2] == {"op_name": "等待秒数", "seconds": 0.02}
 
     hold_operations = operations[3:]
-    press_indices = [
-        index
-        for index, operation in enumerate(hold_operations)
-        if operation.get("op_name") == f"{op_prefix}-按下"
-    ]
-    assert len(press_indices) == 11
-    assert hold_operations[-1]["op_name"] == f"{op_prefix}-松开"
+    expected_hold_operations: list[dict[str, object]] = []
+    for _ in range(11):
+        expected_hold_operations.extend(
+            [
+                {"op_name": f"{op_prefix}-按下"},
+                {"op_name": "等待秒数", "seconds": 0.5},
+            ]
+        )
+    expected_hold_operations.append({"op_name": f"{op_prefix}-松开"})
 
-    for press_index in press_indices:
-        assert hold_operations[press_index + 1] == {
-            "op_name": "等待秒数",
-            "seconds": 0.5,
-        }
+    assert hold_operations == expected_hold_operations

--- a/test/zzz_od/auto_battle/test_remielle_operation_templates.py
+++ b/test/zzz_od/auto_battle/test_remielle_operation_templates.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+
+import pytest
+import yaml
+
+_OPERATION_DIR = Path("config") / "auto_battle_operation"
+_PROTECTION_STATES = {"自定义-动作不打断", "自定义-无视闪光"}
+
+
+def _load_operations(template_name: str) -> list[dict[str, object]]:
+    path = _OPERATION_DIR / f"{template_name}.sample.yml"
+    with path.open(encoding="utf-8") as file:
+        data = yaml.safe_load(file)
+    return data["operations"]
+
+
+@pytest.mark.parametrize(
+    ("template_name", "op_prefix", "opposite_prefix"),
+    [
+        ("蕾米埃尔-长按普攻", "按键-普通攻击", "按键-特殊攻击"),
+        ("蕾米埃尔-长按强化特殊技", "按键-特殊攻击", "按键-普通攻击"),
+    ],
+)
+def test_remielle_long_press_keeps_protection_and_releases_key(
+    template_name: str,
+    op_prefix: str,
+    opposite_prefix: str,
+) -> None:
+    """长按期间续按并最终松键，同时保留原有十秒保护。"""
+    operations = _load_operations(template_name)
+
+    protection = operations[0]
+    assert set(protection["state_list"]) == _PROTECTION_STATES
+    assert protection["seconds"] == 10
+    assert operations[1]["op_name"] == f"{opposite_prefix}-松开"
+    assert operations[2] == {"op_name": "等待秒数", "seconds": 0.02}
+
+    hold_operations = operations[3:]
+    press_indices = [
+        index
+        for index, operation in enumerate(hold_operations)
+        if operation.get("op_name") == f"{op_prefix}-按下"
+    ]
+    assert len(press_indices) == 11
+    assert hold_operations[-1]["op_name"] == f"{op_prefix}-松开"
+
+    for press_index in press_indices:
+        assert hold_operations[press_index + 1] == {
+            "op_name": "等待秒数",
+            "seconds": 0.5,
+        }


### PR DESCRIPTION
## 变更
- 新增蕾米埃尔长按普攻与长按强化特殊技回归测试
- 锁定原有 10 秒「动作不打断 / 无视闪光」保护不变
- 校验每 0.5 秒续按，并在动作末尾明确松键

## 验证
- `uv run pytest zzz-od-test/test/zzz_od/auto_battle/test_remielle_operation_templates.py zzz-od-test/test/zzz_od/auto_battle/test_all_sample_valid.py`
- `uv run ruff check test/zzz_od/auto_battle/test_remielle_operation_templates.py`

## 关联
- 主仓 PR：OneDragon-Anything/ZenlessZoneZero-OneDragon#2665

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **测试**
  * 新增蕾米埃尔自动战斗操作模板的自动化测试。
  * 覆盖长按期间保护状态保持、相反按键释放、重复按键及等待时序验证，提升相关操作模板的稳定性与可靠性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->