### PR TITLE
test(game-settings): 覆盖画质配置保存、恢复和自动切换

### DIFF
--- a/test/zzz_od/application/zzz_application/execute/test_execute.py
+++ b/test/zzz_od/application/zzz_application/execute/test_execute.py
@@ -1,0 +1,53 @@
+from types import SimpleNamespace
+
+import pytest
+
+from one_dragon.base.operation.application_base import Application
+from one_dragon.base.operation.operation_base import OperationResult
+from zzz_od.application.zzz_application import ZApplication
+
+
+class FakeProfileService:
+
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    def enter(self) -> bool:
+        self.calls.append("enter")
+        return True
+
+    def exit(self) -> None:
+        self.calls.append("exit")
+
+
+def _application(service: FakeProfileService) -> ZApplication:
+    app = object.__new__(ZApplication)
+    app.ctx = SimpleNamespace(game_settings_profile_service=service)
+    return app
+
+
+def test_execute_wraps_application_with_profile_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = FakeProfileService()
+    result = OperationResult(success=True, status="完成")
+    monkeypatch.setattr(Application, "execute", lambda self: result)
+
+    assert ZApplication.execute(_application(service)) is result
+    assert service.calls == ["enter", "exit"]
+
+
+def test_execute_restores_profile_when_application_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = FakeProfileService()
+
+    def raise_error(self: Application) -> OperationResult:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(Application, "execute", raise_error)
+
+    with pytest.raises(RuntimeError, match="boom"):
+        ZApplication.execute(_application(service))
+
+    assert service.calls == ["enter", "exit"]

--- a/test/zzz_od/game_settings/game_settings_profile_service/test_enter.py
+++ b/test/zzz_od/game_settings/game_settings_profile_service/test_enter.py
@@ -1,0 +1,108 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from zzz_od.game_settings.game_settings_profile_service import (
+    GameSettingsProfileError,
+    GameSettingsProfileService,
+)
+
+
+def _write_profile(path: Path) -> None:
+    path.write_text(
+        (
+            "Windows Registry Editor Version 5.00\n\n"
+            "[HKEY_CURRENT_USER\\Software\\miHoYo\\绝区零]\n"
+            '"Quality"=dword:00000001\n'
+        ),
+        encoding="utf-8-sig",
+    )
+
+
+def _service(tmp_path: Path) -> tuple[GameSettingsProfileService, Path, Path]:
+    run_path = tmp_path / "run.reg"
+    normal_path = tmp_path / "normal.reg"
+    _write_profile(run_path)
+    _write_profile(normal_path)
+    config = SimpleNamespace(
+        game_settings_profile_enabled=True,
+        game_settings_profile_run_path=str(run_path),
+        game_settings_profile_normal_path=str(normal_path),
+    )
+    ctx = SimpleNamespace(one_dragon_config=config, controller=None)
+    return GameSettingsProfileService(ctx), run_path.resolve(), normal_path.resolve()
+
+
+def test_enter_applies_run_profile_only_for_outer_session(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    service, run_path, _ = _service(tmp_path)
+    calls: list[str] = []
+    monkeypatch.setattr(service, "_close_game", lambda: calls.append("close"))
+    monkeypatch.setattr(
+        service,
+        "_import_profile",
+        lambda path: calls.append(f"import:{path.name}"),
+    )
+
+    assert service.enter()
+    assert service.enter()
+
+    assert calls == ["close", f"import:{run_path.name}"]
+
+
+def test_enter_restores_normal_profile_when_run_import_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    service, run_path, normal_path = _service(tmp_path)
+    calls: list[str] = []
+    monkeypatch.setattr(service, "_close_game", lambda: calls.append("close"))
+
+    def import_profile(path: Path) -> None:
+        calls.append(f"import:{path.name}")
+        if path == run_path:
+            raise GameSettingsProfileError("导入失败")
+
+    monkeypatch.setattr(service, "_import_profile", import_profile)
+
+    with pytest.raises(GameSettingsProfileError, match="导入失败"):
+        service.enter()
+
+    assert calls == [
+        "close",
+        f"import:{run_path.name}",
+        f"import:{normal_path.name}",
+    ]
+    assert service.session_depth == 0
+
+
+def test_enter_keeps_disabled_outer_session_disabled_when_config_changes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = SimpleNamespace(
+        game_settings_profile_enabled=False,
+        game_settings_profile_run_path="",
+        game_settings_profile_normal_path="",
+    )
+    service = GameSettingsProfileService(
+        SimpleNamespace(one_dragon_config=config, controller=None)
+    )
+    calls: list[str] = []
+    monkeypatch.setattr(service, "_close_game", lambda: calls.append("close"))
+    monkeypatch.setattr(
+        service,
+        "_import_profile",
+        lambda path: calls.append(f"import:{path.name}"),
+    )
+
+    assert service.enter()
+    config.game_settings_profile_enabled = True
+    assert service.enter()
+    service.exit()
+    service.exit()
+
+    assert calls == []
+    assert service.session_depth == 0

--- a/test/zzz_od/game_settings/game_settings_profile_service/test_exit.py
+++ b/test/zzz_od/game_settings/game_settings_profile_service/test_exit.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 import pytest
 
 from zzz_od.game_settings.game_settings_profile_service import (
+    GameSettingsProfileError,
     GameSettingsProfileService,
 )
 
@@ -55,4 +56,41 @@ def test_exit_restores_normal_profile_after_outer_session(
         "close",
         "import:normal.reg",
     ]
+    assert service.session_depth == 0
+
+
+def test_exit_does_not_import_normal_profile_when_game_close_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    run_path = tmp_path / "run.reg"
+    normal_path = tmp_path / "normal.reg"
+    _write_profile(run_path)
+    _write_profile(normal_path)
+    config = SimpleNamespace(
+        game_settings_profile_enabled=True,
+        game_settings_profile_run_path=str(run_path),
+        game_settings_profile_normal_path=str(normal_path),
+    )
+    service = GameSettingsProfileService(
+        SimpleNamespace(one_dragon_config=config, controller=None)
+    )
+    imported_profiles: list[str] = []
+    monkeypatch.setattr(service, "_close_game", lambda: None)
+    monkeypatch.setattr(
+        service,
+        "_import_profile",
+        lambda path: imported_profiles.append(path.name),
+    )
+    service.enter()
+
+    def fail_to_close_game() -> None:
+        raise GameSettingsProfileError("关闭超时")
+
+    monkeypatch.setattr(service, "_close_game", fail_to_close_game)
+
+    with pytest.raises(GameSettingsProfileError, match="关闭超时"):
+        service.exit()
+
+    assert imported_profiles == ["run.reg"]
     assert service.session_depth == 0

--- a/test/zzz_od/game_settings/game_settings_profile_service/test_exit.py
+++ b/test/zzz_od/game_settings/game_settings_profile_service/test_exit.py
@@ -1,0 +1,58 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from zzz_od.game_settings.game_settings_profile_service import (
+    GameSettingsProfileService,
+)
+
+
+def _write_profile(path: Path) -> None:
+    path.write_text(
+        (
+            "Windows Registry Editor Version 5.00\n\n"
+            "[HKEY_CURRENT_USER\\Software\\miHoYo\\绝区零]\n"
+            '"Quality"=dword:00000001\n'
+        ),
+        encoding="utf-8-sig",
+    )
+
+
+def test_exit_restores_normal_profile_after_outer_session(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    run_path = tmp_path / "run.reg"
+    normal_path = tmp_path / "normal.reg"
+    _write_profile(run_path)
+    _write_profile(normal_path)
+    config = SimpleNamespace(
+        game_settings_profile_enabled=True,
+        game_settings_profile_run_path=str(run_path),
+        game_settings_profile_normal_path=str(normal_path),
+    )
+    service = GameSettingsProfileService(
+        SimpleNamespace(one_dragon_config=config, controller=None)
+    )
+    calls: list[str] = []
+    monkeypatch.setattr(service, "_close_game", lambda: calls.append("close"))
+    monkeypatch.setattr(
+        service,
+        "_import_profile",
+        lambda path: calls.append(f"import:{path.name}"),
+    )
+
+    service.enter()
+    service.enter()
+    service.exit()
+    assert calls == ["close", "import:run.reg"]
+
+    service.exit()
+    assert calls == [
+        "close",
+        "import:run.reg",
+        "close",
+        "import:normal.reg",
+    ]
+    assert service.session_depth == 0

--- a/test/zzz_od/game_settings/game_settings_profile_service/test_game_settings_profile_close_game.py
+++ b/test/zzz_od/game_settings/game_settings_profile_service/test_game_settings_profile_close_game.py
@@ -1,0 +1,57 @@
+from types import SimpleNamespace
+
+import pytest
+
+from zzz_od.game_settings import game_settings_profile_service as service_module
+from zzz_od.game_settings.game_settings_profile_service import (
+    GameSettingsProfileError,
+    GameSettingsProfileService,
+)
+
+
+class FakeController:
+
+    def __init__(self, closes_successfully: bool) -> None:
+        self.is_game_window_ready: bool = True
+        self.closes_successfully: bool = closes_successfully
+        self.close_calls: int = 0
+
+    def init_game_win(self) -> bool:
+        return self.is_game_window_ready
+
+    def close_game(self) -> None:
+        self.close_calls += 1
+        if self.closes_successfully:
+            self.is_game_window_ready = False
+
+
+def _service(controller: FakeController) -> GameSettingsProfileService:
+    ctx = SimpleNamespace(controller=controller, one_dragon_config=SimpleNamespace())
+    return GameSettingsProfileService(ctx)
+
+
+def test_close_game_waits_until_window_disappears(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    controller = FakeController(closes_successfully=True)
+    sleep_calls: list[float] = []
+    monkeypatch.setattr(service_module.time, "sleep", sleep_calls.append)
+
+    _service(controller)._close_game()
+
+    assert controller.close_calls == 1
+    assert sleep_calls == [0.5, 2]
+
+
+def test_close_game_fails_when_window_stays_open(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    controller = FakeController(closes_successfully=False)
+    timestamps = iter([0.0, 31.0])
+    monkeypatch.setattr(service_module.time, "monotonic", lambda: next(timestamps))
+    monkeypatch.setattr(service_module.time, "sleep", lambda seconds: None)
+
+    with pytest.raises(GameSettingsProfileError, match="关闭超时"):
+        _service(controller)._close_game()
+
+    assert controller.close_calls == 1

--- a/test/zzz_od/game_settings/game_settings_profile_service/test_import_profile.py
+++ b/test/zzz_od/game_settings/game_settings_profile_service/test_import_profile.py
@@ -1,0 +1,47 @@
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from zzz_od.game_settings import game_settings_profile_service as service_module
+from zzz_od.game_settings.game_settings_profile_service import (
+    GameSettingsProfileError,
+    GameSettingsProfileService,
+)
+
+
+def test_import_profile_calls_reg_without_shell(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    profile_path = tmp_path / "profile.reg"
+    run_calls: list[tuple[list[str], dict]] = []
+    monkeypatch.setattr(service_module.shutil, "which", lambda executable: "reg.exe")
+
+    def run(command: list[str], **kwargs) -> subprocess.CompletedProcess:
+        run_calls.append((command, kwargs))
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr(service_module.subprocess, "run", run)
+
+    GameSettingsProfileService._import_profile(profile_path)
+
+    assert run_calls[0][0] == ["reg.exe", "import", str(profile_path), "/reg:64"]
+    assert "shell" not in run_calls[0][1]
+    assert run_calls[0][1]["timeout"] == 30
+
+
+def test_import_profile_reports_reg_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    profile_path = tmp_path / "profile.reg"
+    monkeypatch.setattr(service_module.shutil, "which", lambda executable: "reg.exe")
+    monkeypatch.setattr(
+        service_module.subprocess,
+        "run",
+        lambda command, **kwargs: subprocess.CompletedProcess(command, 1),
+    )
+
+    with pytest.raises(GameSettingsProfileError, match="返回 1"):
+        GameSettingsProfileService._import_profile(profile_path)

--- a/test/zzz_od/game_settings/game_settings_profile_service/test_manual_profile_actions.py
+++ b/test/zzz_od/game_settings/game_settings_profile_service/test_manual_profile_actions.py
@@ -1,0 +1,197 @@
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from one_dragon.base.config.game_account_config import GameRegionEnum
+from zzz_od.game_settings import game_settings_profile_service as service_module
+from zzz_od.game_settings.game_settings_profile_service import (
+    GameSettingsProfileError,
+    GameSettingsProfileService,
+)
+
+
+def _write_profile(profile_path: Path, registry_key: str) -> None:
+    profile_path.write_text(
+        (
+            'Windows Registry Editor Version 5.00\n\n'
+            f'[{registry_key}]\n'
+            '"Quality"=dword:00000001\n'
+        ),
+        encoding='utf-16',
+    )
+
+
+def _service(
+    game_region: str,
+    normal_profile_path: str = '',
+) -> GameSettingsProfileService:
+    config = SimpleNamespace(
+        game_settings_profile_enabled=False,
+        game_settings_profile_normal_path=normal_profile_path,
+    )
+    ctx = SimpleNamespace(
+        controller=None,
+        game_account_config=SimpleNamespace(game_region=game_region),
+        one_dragon_config=config,
+    )
+    return GameSettingsProfileService(ctx)
+
+
+@pytest.mark.parametrize(
+    ('game_region', 'registry_key'),
+    [
+        (
+            GameRegionEnum.CN.value.value,
+            r'HKEY_CURRENT_USER\Software\miHoYo\绝区零',
+        ),
+        (
+            GameRegionEnum.CNB.value.value,
+            r'HKEY_CURRENT_USER\Software\miHoYo\绝区零',
+        ),
+        (
+            GameRegionEnum.AMERICA.value.value,
+            r'HKEY_CURRENT_USER\Software\miHoYo\ZenlessZoneZero',
+        ),
+    ],
+)
+def test_export_profile_closes_game_and_uses_current_region(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    game_region: str,
+    registry_key: str,
+) -> None:
+    service = _service(game_region)
+    calls: list[str] = []
+    monkeypatch.setattr(service, '_close_game', lambda: calls.append('close'))
+
+    def export_registry_key(key: str, profile_path: Path) -> None:
+        calls.append(f'export:{key}:{profile_path.name}')
+        _write_profile(profile_path, key)
+
+    monkeypatch.setattr(service, '_export_registry_key', export_registry_key)
+
+    result = service.export_profile(str(tmp_path / 'profile'))
+
+    assert result == (tmp_path / 'profile.reg').resolve()
+    assert calls == ['close', f'export:{registry_key}:profile.reg']
+
+
+def test_export_profile_rejects_missing_parent_before_closing_game(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    service = _service(GameRegionEnum.CN.value.value)
+    calls: list[str] = []
+    monkeypatch.setattr(service, '_close_game', lambda: calls.append('close'))
+
+    with pytest.raises(GameSettingsProfileError, match='保存目录不存在'):
+        service.export_profile(str(tmp_path / 'missing' / 'profile.reg'))
+
+    assert calls == []
+
+
+def test_export_profile_rejects_manual_action_during_automation(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    service = _service(GameRegionEnum.CN.value.value)
+    service.enter()
+    calls: list[str] = []
+    monkeypatch.setattr(service, '_close_game', lambda: calls.append('close'))
+
+    with pytest.raises(GameSettingsProfileError, match='运行中'):
+        service.export_profile(str(tmp_path / 'profile.reg'))
+
+    assert calls == []
+
+
+def test_export_profile_rejects_action_while_profile_is_switching(
+    tmp_path: Path,
+) -> None:
+    service = _service(GameRegionEnum.CN.value.value)
+    service._action_lock.acquire()
+    try:
+        with pytest.raises(GameSettingsProfileError, match='正在切换'):
+            service.export_profile(str(tmp_path / 'profile.reg'))
+    finally:
+        service._action_lock.release()
+
+
+def test_export_registry_key_calls_reg_without_shell(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    profile_path = tmp_path / 'profile.reg'
+    registry_key = r'HKEY_CURRENT_USER\Software\miHoYo\绝区零'
+    run_calls: list[tuple[list[str], dict[str, object]]] = []
+    monkeypatch.setattr(service_module.shutil, 'which', lambda executable: 'reg.exe')
+
+    def run(
+        command: list[str],
+        **kwargs: object,
+    ) -> subprocess.CompletedProcess[bytes]:
+        run_calls.append((command, kwargs))
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr(service_module.subprocess, 'run', run)
+
+    GameSettingsProfileService._export_registry_key(registry_key, profile_path)
+
+    assert run_calls[0][0] == [
+        'reg.exe',
+        'export',
+        registry_key,
+        str(profile_path),
+        '/y',
+        '/reg:64',
+    ]
+    assert 'shell' not in run_calls[0][1]
+    assert run_calls[0][1]['timeout'] == 30
+
+
+def test_restore_normal_profile_closes_game_before_import(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    normal_profile_path = tmp_path / 'normal.reg'
+    registry_key = r'HKEY_CURRENT_USER\Software\miHoYo\绝区零'
+    _write_profile(normal_profile_path, registry_key)
+    service = _service(
+        GameRegionEnum.CN.value.value,
+        normal_profile_path=str(normal_profile_path),
+    )
+    calls: list[str] = []
+    monkeypatch.setattr(service, '_close_game', lambda: calls.append('close'))
+    monkeypatch.setattr(
+        service,
+        '_import_profile',
+        lambda path: calls.append(f'import:{path.name}'),
+    )
+
+    result = service.restore_normal_profile()
+
+    assert result == normal_profile_path.resolve()
+    assert calls == ['close', 'import:normal.reg']
+
+
+def test_restore_normal_profile_rejects_manual_action_during_automation(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    normal_profile_path = tmp_path / 'normal.reg'
+    registry_key = r'HKEY_CURRENT_USER\Software\miHoYo\绝区零'
+    _write_profile(normal_profile_path, registry_key)
+    service = _service(
+        GameRegionEnum.CN.value.value,
+        normal_profile_path=str(normal_profile_path),
+    )
+    service.enter()
+    calls: list[str] = []
+    monkeypatch.setattr(service, '_close_game', lambda: calls.append('close'))
+
+    with pytest.raises(GameSettingsProfileError, match='运行中'):
+        service.restore_normal_profile()
+
+    assert calls == []

--- a/test/zzz_od/game_settings/game_settings_profile_service/test_validate_profile.py
+++ b/test/zzz_od/game_settings/game_settings_profile_service/test_validate_profile.py
@@ -1,0 +1,67 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from zzz_od.game_settings.game_settings_profile_service import (
+    GameSettingsProfileError,
+    GameSettingsProfileService,
+)
+
+
+def _service() -> GameSettingsProfileService:
+    ctx = SimpleNamespace(one_dragon_config=SimpleNamespace())
+    return GameSettingsProfileService(ctx)
+
+
+@pytest.mark.parametrize(
+    ("registry_key", "encoding"),
+    [
+        (r"HKEY_CURRENT_USER\Software\miHoYo\绝区零", "utf-16"),
+        (r"HKEY_CURRENT_USER\Software\miHoYo\ZenlessZoneZero", "utf-8-sig"),
+    ],
+)
+def test_validate_profile_accepts_zzz_keys(
+    tmp_path: Path,
+    registry_key: str,
+    encoding: str,
+) -> None:
+    profile_path = tmp_path / "profile.reg"
+    profile_path.write_text(
+        f'Windows Registry Editor Version 5.00\n\n[{registry_key}]\n"Quality"=dword:00000001\n',
+        encoding=encoding,
+    )
+
+    assert _service().validate_profile(str(profile_path)) == profile_path.resolve()
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        '[HKEY_CURRENT_USER\\Software\\OtherGame]\n"Quality"=dword:00000001\n',
+        (
+            '[HKEY_CURRENT_USER\\Software\\miHoYo\\绝区零]\n'
+            '"Quality"=dword:00000001\n\n'
+            '[HKEY_CURRENT_USER\\Software\\Microsoft]\n'
+            '"Value"=dword:00000001\n'
+        ),
+        '[-HKEY_CURRENT_USER\\Software\\miHoYo\\绝区零]\n',
+    ],
+)
+def test_validate_profile_rejects_keys_outside_zzz(tmp_path: Path, body: str) -> None:
+    profile_path = tmp_path / "profile.reg"
+    profile_path.write_text(
+        f"Windows Registry Editor Version 5.00\n\n{body}",
+        encoding="utf-8-sig",
+    )
+
+    with pytest.raises(GameSettingsProfileError, match="只允许"):
+        _service().validate_profile(str(profile_path))
+
+
+def test_validate_profile_rejects_non_reg_file(tmp_path: Path) -> None:
+    profile_path = tmp_path / "profile.txt"
+    profile_path.write_text("not a registry profile", encoding="utf-8")
+
+    with pytest.raises(GameSettingsProfileError, match=".reg"):
+        _service().validate_profile(str(profile_path))

--- a/test/zzz_od/game_settings/game_settings_profile_service/test_validate_profile.py
+++ b/test/zzz_od/game_settings/game_settings_profile_service/test_validate_profile.py
@@ -63,5 +63,5 @@ def test_validate_profile_rejects_non_reg_file(tmp_path: Path) -> None:
     profile_path = tmp_path / "profile.txt"
     profile_path.write_text("not a registry profile", encoding="utf-8")
 
-    with pytest.raises(GameSettingsProfileError, match=".reg"):
+    with pytest.raises(GameSettingsProfileError, match=r"\.reg"):
         _service().validate_profile(str(profile_path))

--- a/test/zzz_od/game_settings/game_settings_profile_service/test_validate_profile.py
+++ b/test/zzz_od/game_settings/game_settings_profile_service/test_validate_profile.py
@@ -65,3 +65,18 @@ def test_validate_profile_rejects_non_reg_file(tmp_path: Path) -> None:
 
     with pytest.raises(GameSettingsProfileError, match=r"\.reg"):
         _service().validate_profile(str(profile_path))
+
+
+def test_validate_profile_wraps_file_system_error(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    profile_path = tmp_path / "profile.reg"
+
+    def raise_permission_error(path: Path) -> bool:
+        raise PermissionError("denied")
+
+    monkeypatch.setattr(Path, "is_file", raise_permission_error)
+
+    with pytest.raises(GameSettingsProfileError, match="无法读取"):
+        _service().validate_profile(str(profile_path))


### PR DESCRIPTION
## 原因

为 `OneDragon-Anything/ZenlessZoneZero-OneDragon#2670` 的画质配置保存、恢复和自动切换提供独立测试，防止注册表越界写入、并发切换或异常退出时漏恢复。

## 改动

- 覆盖国服、B 服和国际服保存时的注册表键选择
- 覆盖自动补全 `.reg`、无效目录、运行中操作和切换互斥
- 覆盖 `reg.exe export` 参数、关闭游戏后保存，以及立即恢复正常画质
- 保留原有文件校验、嵌套切换、导入失败回滚和应用异常恢复覆盖

## 验证

- 画质服务与应用退出相关测试：27 passed
- 可比全仓回归：677 passed, 4 skipped, 10 deselected

关联主仓 PR：OneDragon-Anything/ZenlessZoneZero-OneDragon#2670
关联需求：OneDragon-Anything/ZenlessZoneZero-OneDragon#2380