### PR TITLE
test: OCR v5 到 v6 平滑迁移单元测试

### DIFF
--- a/test/one_dragon/base/cv_process/test_cv_service_multi_source.py
+++ b/test/one_dragon/base/cv_process/test_cv_service_multi_source.py
@@ -1,0 +1,174 @@
+# coding: utf-8
+"""CvService 多目录来源解析 + cvpipe 拿框方法的单元测试（全部 mock，不落盘）"""
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+from one_dragon.base.cv_process.cv_service import (
+    CvService,
+    reset_current_plugin,
+    set_current_plugin,
+)
+from one_dragon.base.geometry.rectangle import Rect
+from one_dragon.base.screen.screen_area import ScreenArea
+from one_dragon.base.screen.screen_utils import find_area_box
+
+
+def _create_service() -> CvService:
+    """创建 mock 上下文的 CvService，插件流水线目录可注入"""
+    ctx = MagicMock()
+    ctx.application_plugin_dirs = []
+    service = CvService(ctx)
+    # 模拟一个插件流水线目录：插件名 test_plugin
+    service._plugin_pipeline_dirs = [('test_plugin', '/fake/plugins/test_plugin/assets/image_analysis_pipelines')]
+    return service
+
+
+def _mock_pipeline_context(rects: list[tuple[int, int, int, int]]):
+    """构造返回指定轮廓框的流水线上下文 mock"""
+    ctx = MagicMock()
+    ctx.is_success = True
+    ctx.get_absolute_rects.return_value = rects
+    return ctx
+
+
+# ==================== CvService 多目录 / 来源解析 ====================
+
+def test_get_pipeline_names_by_source():
+    """按来源过滤：主仓与插件分别返回自己的裸名列表，不混排"""
+    service = _create_service()
+    with patch('os.listdir', side_effect=[['a.yml', 'b.yml'], ['b.yml', 'c.yml']]):
+        with patch('os.path.isdir', return_value=True):
+            main_names = service.get_pipeline_names('')
+            plugin_names = service.get_pipeline_names('test_plugin')
+
+    assert main_names == ['a', 'b']
+    assert plugin_names == ['b', 'c']
+
+
+def test_load_pipeline_by_explicit_source():
+    """显式 source 加载：插件名只查插件目录"""
+    service = _create_service()
+    with patch('os.path.exists', return_value=True), \
+         patch('builtins.open', MagicMock()), \
+         patch('one_dragon.base.cv_process.cv_service.yaml_utils.safe_load', return_value=None):
+        pipeline = service.load_pipeline('b', source='test_plugin')
+    assert pipeline is not None
+
+
+def test_load_pipeline_bare_name_plugin_context_first():
+    """裸名 + 插件上下文：优先解析自身插件目录，其次主仓"""
+    service = _create_service()
+    calls = []
+
+    def fake_exists(path):
+        calls.append(path)
+        # 插件目录里的文件存在，主仓不存在 → 应命中插件
+        return 'test_plugin' in str(path)
+
+    with patch('os.path.exists', side_effect=fake_exists), \
+         patch('builtins.open', MagicMock()), \
+         patch('one_dragon.base.cv_process.cv_service.yaml_utils.safe_load', return_value=None):
+        token = set_current_plugin('test_plugin')
+        try:
+            pipeline = service.load_pipeline('b')
+        finally:
+            reset_current_plugin(token)
+
+    assert pipeline is not None
+    assert any('test_plugin' in c for c in calls), '应优先查插件目录'
+
+
+def test_load_pipeline_bare_name_main_when_no_plugin_context():
+    """裸名 + 主仓上下文：直接查主仓目录"""
+    service = _create_service()
+    with patch('os.path.exists', return_value=True), \
+         patch('builtins.open', MagicMock()), \
+         patch('one_dragon.base.cv_process.cv_service.yaml_utils.safe_load', return_value=None):
+        pipeline = service.load_pipeline('a')
+    assert pipeline is not None
+
+
+def test_save_pipeline_to_plugin():
+    """保存到插件来源：写入插件目录"""
+    service = _create_service()
+    with patch('builtins.open', MagicMock()) as mock_open:
+        ok = service.save_pipeline('c', MagicMock(), source='test_plugin')
+    assert ok is True
+    opened_path = mock_open.call_args[0][0]
+    assert 'test_plugin' in opened_path
+
+
+# ==================== cvpipe 拿框方法 ====================
+
+def _create_cvpipe_area() -> ScreenArea:
+    """构造 cvpipe 区域：pc_rect 偏移 (100, 200)，流水线输出裁剪图内轮廓框"""
+    return ScreenArea(
+        area_name='测试',
+        pc_rect=Rect(100, 200, 500, 600),
+        text='确定',
+        cvpipe='电量检测',
+    )
+
+
+def test_find_area_box_cvpipe_coord_synthesis():
+    """cvpipe 拿框：cv 框坐标 + pc_rect 偏移合成真实坐标"""
+    area = _create_cvpipe_area()
+    ctx = MagicMock()
+    # 流水线在裁剪图上输出轮廓框 (10, 20, 50, 60)
+    ctx.cv_service.run_pipeline.return_value = _mock_pipeline_context([(10, 20, 50, 60)])
+    # 框内 OCR 匹配成功（text='确定'）
+    ocr_result = MagicMock()
+    ocr_result.data = '确定'
+    ctx.ocr_service.get_ocr_result_list.return_value = [ocr_result]
+
+    box = find_area_box(ctx, np.zeros((1080, 1920, 3), dtype=np.uint8), area)
+
+    assert box == (110, 220, 150, 260), f'合成坐标错误: {box}'
+
+
+def test_find_area_box_cvpipe_verify_each_box_first_hit():
+    """cvpipe 拿框：多个候选框逐个验证，第一个命中立即返回"""
+    area = _create_cvpipe_area()
+    ctx = MagicMock()
+    # 两个候选框：第一个框内 OCR 不匹配，第二个匹配
+    ctx.cv_service.run_pipeline.return_value = _mock_pipeline_context([(10, 20, 50, 60), (70, 80, 120, 130)])
+
+    def fake_ocr(image, rect, color_range, crop_first):
+        # 第一个框 (110,220,150,260) 返回不匹配文字；第二个框返回「确定」
+        if rect.x1 == 110:
+            return [MagicMock(data='其他')]
+        return [MagicMock(data='确定')]
+
+    ctx.ocr_service.get_ocr_result_list.side_effect = fake_ocr
+
+    box = find_area_box(ctx, np.zeros((1080, 1920, 3), dtype=np.uint8), area)
+
+    assert box == (170, 280, 220, 330), f'应返回第二个命中框: {box}'
+
+
+def test_find_area_box_cvpipe_all_fail_returns_none():
+    """cvpipe 拿框：所有候选框验证失败返回 None（拿框可能为空）"""
+    area = _create_cvpipe_area()
+    ctx = MagicMock()
+    ctx.cv_service.run_pipeline.return_value = _mock_pipeline_context([(10, 20, 50, 60)])
+    ctx.ocr_service.get_ocr_result_list.return_value = [MagicMock(data='其他')]
+
+    box = find_area_box(ctx, np.zeros((1080, 1920, 3), dtype=np.uint8), area)
+
+    assert box is None
+
+
+def test_find_area_box_cvpipe_pipeline_fail_returns_none():
+    """cvpipe 拿框：流水线执行失败返回 None"""
+    area = _create_cvpipe_area()
+    ctx = MagicMock()
+    failed_ctx = MagicMock()
+    failed_ctx.is_success = False
+    ctx.cv_service.run_pipeline.return_value = failed_ctx
+
+    box = find_area_box(ctx, np.zeros((1080, 1920, 3), dtype=np.uint8), area)
+
+    assert box is None

--- a/test/one_dragon/base/operation/test_ocr_v6_smooth_upgrade.py
+++ b/test/one_dragon/base/operation/test_ocr_v6_smooth_upgrade.py
@@ -1,0 +1,177 @@
+from unittest import mock
+
+import pytest
+
+from one_dragon.base.matcher.ocr.onnx_ocr_matcher import (
+    DEFAULT_OCR_MODEL_NAME,
+    PPOCRV6_MODEL_NAME,
+)
+from one_dragon.base.operation.one_dragon_context import OneDragonContext
+
+
+class TestOcrModelDecision:
+
+    def _make_context(self, is_debug: bool, config_ocr: str) -> OneDragonContext:
+        """
+        构造一个轻量上下文 绕过重量级 __init__
+        """
+        ctx = OneDragonContext.__new__(OneDragonContext)
+        ctx.env_config = mock.Mock()
+        ctx.env_config.is_debug = is_debug
+        ctx.model_config = mock.Mock()
+        ctx.model_config.ocr = config_ocr
+        ctx.model_config.update = lambda name, val: setattr(ctx.model_config, 'ocr', val)
+        ctx._ocr_v6_downloading = False
+        return ctx
+
+    def test_debug_mode_uses_config(self):
+        """
+        调试模式: 直接用配置里的模型 不自动切换
+        """
+        ctx = self._make_context(is_debug=True, config_ocr=DEFAULT_OCR_MODEL_NAME)
+        with mock.patch.object(
+                OneDragonContext, '_is_ocr_model_ready',
+                side_effect=lambda name: {PPOCRV6_MODEL_NAME: True, DEFAULT_OCR_MODEL_NAME: True}[name],
+        ):
+            assert ctx._decide_ocr_model_name() == DEFAULT_OCR_MODEL_NAME
+
+    def test_v6_ready_uses_v6(self):
+        """
+        正常模式 仅 V6 就绪: 用 V6
+        """
+        ctx = self._make_context(is_debug=False, config_ocr=DEFAULT_OCR_MODEL_NAME)
+        with mock.patch.object(
+                OneDragonContext, '_is_ocr_model_ready',
+                side_effect=lambda name: {PPOCRV6_MODEL_NAME: True, DEFAULT_OCR_MODEL_NAME: False}[name],
+        ):
+            assert ctx._decide_ocr_model_name() == PPOCRV6_MODEL_NAME
+
+    def test_v5_ready_uses_v5(self):
+        """
+        正常模式 仅 V5 就绪: 先用 V5 顶住
+        """
+        ctx = self._make_context(is_debug=False, config_ocr=PPOCRV6_MODEL_NAME)
+        with mock.patch.object(
+                OneDragonContext, '_is_ocr_model_ready',
+                side_effect=lambda name: {PPOCRV6_MODEL_NAME: False, DEFAULT_OCR_MODEL_NAME: True}[name],
+        ):
+            assert ctx._decide_ocr_model_name() == DEFAULT_OCR_MODEL_NAME
+
+    def test_none_ready_uses_v6(self):
+        """
+        正常模式 都没有: 直接用 V6 触发下载
+        """
+        ctx = self._make_context(is_debug=False, config_ocr=DEFAULT_OCR_MODEL_NAME)
+        with mock.patch.object(
+                OneDragonContext, '_is_ocr_model_ready',
+                side_effect=lambda name: {PPOCRV6_MODEL_NAME: False, DEFAULT_OCR_MODEL_NAME: False}[name],
+        ):
+            assert ctx._decide_ocr_model_name() == PPOCRV6_MODEL_NAME
+
+
+class TestOcrV6BackgroundDownload:
+
+    def _make_context(self) -> OneDragonContext:
+        """
+        构造一个轻量上下文
+        """
+        ctx = OneDragonContext.__new__(OneDragonContext)
+        ctx.env_config = mock.Mock()
+        ctx.env_config.is_debug = False
+        ctx.env_config.is_gh_proxy = False
+        ctx.env_config.gh_proxy_url = ''
+        ctx.env_config.is_personal_proxy = False
+        ctx.env_config.personal_proxy = ''
+        ctx.model_config = mock.Mock()
+        ctx.model_config.ocr = DEFAULT_OCR_MODEL_NAME
+        ctx.model_config.update = lambda name, val: setattr(ctx.model_config, 'ocr', val)
+        ctx._ocr_v6_downloading = False
+        return ctx
+
+    def _run_download_task(self, ctx: OneDragonContext, download_result) -> mock.Mock:
+        """
+        同步执行后台下载逻辑 返回 init_ocr 的 mock
+        """
+        fake_matcher = mock.Mock()
+        fake_matcher.download = mock.Mock(return_value=download_result)
+
+        with mock.patch(
+                'one_dragon.base.operation.one_dragon_context.OnnxOcrMatcher',
+                return_value=fake_matcher,
+        ):
+            with mock.patch(
+                    'one_dragon.base.operation.one_dragon_context.threading.Thread',
+            ) as mock_thread:
+                with mock.patch.object(OneDragonContext, 'init_ocr') as mock_init:
+                    # 让 start 同步执行线程目标
+                    def sync_start():
+                        target = mock_thread.call_args.kwargs['target']
+                        target()
+
+                    mock_thread.return_value.start = sync_start
+                    ctx._download_ocr_v6_in_background()
+                    return mock_init
+
+    def test_download_success_only_persists_config(self):
+        """
+        下载成功: 只落盘配置 不立刻切换 下次启动生效
+        """
+        ctx = self._make_context()
+        mock_init = self._run_download_task(ctx, download_result=True)
+
+        # 落盘配置为 v6
+        assert ctx.model_config.ocr == PPOCRV6_MODEL_NAME
+        # 不立刻切换
+        mock_init.assert_not_called()
+
+    def test_download_failure_keeps_v5(self):
+        """
+        下载失败: 不落盘 保持 V5 配置
+        """
+        ctx = self._make_context()
+        self._run_download_task(ctx, download_result=False)
+
+        assert ctx.model_config.ocr == DEFAULT_OCR_MODEL_NAME
+
+    def test_download_exception_keeps_v5(self):
+        """
+        下载异常: 不落盘 保持 V5 配置 状态复位
+        """
+        ctx = self._make_context()
+
+        fake_matcher = mock.Mock()
+        fake_matcher.download = mock.Mock(side_effect=RuntimeError('网络异常'))
+
+        with mock.patch(
+                'one_dragon.base.operation.one_dragon_context.OnnxOcrMatcher',
+                return_value=fake_matcher,
+        ):
+            with mock.patch(
+                    'one_dragon.base.operation.one_dragon_context.threading.Thread',
+            ) as mock_thread:
+                def sync_start():
+                    target = mock_thread.call_args.kwargs['target']
+                    target()
+
+                mock_thread.return_value.start = sync_start
+                ctx._download_ocr_v6_in_background()
+
+        assert ctx.model_config.ocr == DEFAULT_OCR_MODEL_NAME
+        # 状态复位 下次可重试
+        assert ctx._ocr_v6_downloading is False
+
+    def test_no_duplicate_download(self):
+        """
+        下载进行中 不重复启动
+        """
+        ctx = self._make_context()
+        ctx._ocr_v6_downloading = True
+        with mock.patch(
+                'one_dragon.base.operation.one_dragon_context.OnnxOcrMatcher',
+        ) as mock_matcher:
+            ctx._download_ocr_v6_in_background()
+            mock_matcher.assert_not_called()
+
+
+if __name__ == '__main__':
+    pytest.main(['-v', __file__])

--- a/test/one_dragon_qt/logic/test_image_analysis_logic.py
+++ b/test/one_dragon_qt/logic/test_image_analysis_logic.py
@@ -22,7 +22,8 @@ def test_auto_save_pipeline_generates_first_name():
 
     assert name == '流水线1'
     assert logic.active_pipeline_name == '流水线1'
-    logic.cv_service.save_pipeline.assert_called_once_with('流水线1', logic.pipeline)
+    logic.cv_service.get_pipeline_names.assert_called_once_with(source='')
+    logic.cv_service.save_pipeline.assert_called_once_with('流水线1', logic.pipeline, source='')
 
 
 def test_auto_save_pipeline_skips_existing_names():

--- a/test/one_dragon_qt/logic/test_image_analysis_logic.py
+++ b/test/one_dragon_qt/logic/test_image_analysis_logic.py
@@ -1,0 +1,48 @@
+# coding: utf-8
+from unittest.mock import MagicMock
+
+from one_dragon_qt.logic.image_analysis_logic import ImageAnalysisLogic
+
+
+def _create_logic() -> ImageAnalysisLogic:
+    """创建一个使用 mock cv_service 的 ImageAnalysisLogic，不触碰真实文件"""
+    ctx = MagicMock()
+    ctx.cv_service = MagicMock()
+    logic = ImageAnalysisLogic(ctx)
+    logic.cv_service.get_pipeline_names.return_value = []
+    logic.cv_service.save_pipeline.return_value = True
+    return logic
+
+
+def test_auto_save_pipeline_generates_first_name():
+    """没有已保存流水线时，自动保存为「流水线1」"""
+    logic = _create_logic()
+
+    name = logic.auto_save_pipeline()
+
+    assert name == '流水线1'
+    assert logic.active_pipeline_name == '流水线1'
+    logic.cv_service.save_pipeline.assert_called_once_with('流水线1', logic.pipeline)
+
+
+def test_auto_save_pipeline_skips_existing_names():
+    """已存在「流水线1」「流水线2」时，自动保存为「流水线3」，不覆盖已有文件"""
+    logic = _create_logic()
+    logic.cv_service.get_pipeline_names.return_value = ['流水线1', '流水线2']
+
+    name = logic.auto_save_pipeline()
+
+    assert name == '流水线3'
+    assert logic.active_pipeline_name == '流水线3'
+
+
+def test_auto_save_pipeline_save_failed():
+    """保存失败时返回 None，且不修改当前激活的流水线名称"""
+    logic = _create_logic()
+    logic.active_pipeline_name = None
+    logic.cv_service.save_pipeline.return_value = False
+
+    name = logic.auto_save_pipeline()
+
+    assert name is None
+    assert logic.active_pipeline_name is None


### PR DESCRIPTION
## 为什么改

主仓 PR https://github.com/OneDragon-Anything/ZenlessZoneZero-OneDragon/pull/2681 实现 OCR v5→v6 平滑迁移，编程兔 review 要求补单元测试。

## 改动要点

- _decide_ocr_model_name 决策矩阵：调试模式、仅 V6 就绪、仅 V5 就绪、两者缺失
- _download_ocr_v6_in_background：下载成功只落盘不切换、下载失败保持 V5、下载异常状态复位、防重复下载